### PR TITLE
Update go

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Go library that implements a Sparse Merkle tree for a key-value map. The tree implements the same optimisations specified in the [Libra whitepaper][libra whitepaper], to reduce the number of hash operations required per tree operation to O(k) where k is the number of non-empty elements in the tree.
 
-[![Tests](https://github.com/celestiaorg/smt/actions/workflows/test.yml/badge.svg)](https://github.com/celestiaorg/smt/actions/workflows/test.yml)
-[![codecov](https://codecov.io/gh/celestiaorg/smt/branch/master/graph/badge.svg?token=U3GGEDSA94)](https://codecov.io/gh/celestiaorg/smt)
-[![GoDoc](https://godoc.org/github.com/celestiaorg/smt?status.svg)](https://godoc.org/github.com/celestiaorg/smt)
+[![Tests](https://github.com/pokt-network/smt/actions/workflows/test.yml/badge.svg)](https://github.com/pokt-network/smt/actions/workflows/test.yml)
+[![codecov](https://codecov.io/gh/pokt-network/smt/branch/master/graph/badge.svg?token=U3GGEDSA94)](https://codecov.io/gh/pokt-network/smt)
+[![GoDoc](https://godoc.org/github.com/pokt-network/smt?status.svg)](https://godoc.org/github.com/pokt-network/smt)
 
 ## Example
 
@@ -15,7 +15,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 
-	"github.com/celestiaorg/smt"
+	"github.com/pokt-network/smt"
 )
 
 func main() {

--- a/fuzz/delete/fuzz.go
+++ b/fuzz/delete/fuzz.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 
-	"github.com/celestiaorg/smt"
+	"github.com/pokt-network/smt"
 )
 
 func Fuzz(data []byte) int {

--- a/fuzz/fuzz.go
+++ b/fuzz/fuzz.go
@@ -6,7 +6,7 @@ import (
 	"encoding/binary"
 	"math"
 
-	"github.com/celestiaorg/smt"
+	"github.com/pokt-network/smt"
 )
 
 func Fuzz(input []byte) int {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/pokt-network/smt
 
-go 1.14
+go 1.18

--- a/oss-fuzz-build.sh
+++ b/oss-fuzz-build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-export FUZZ_ROOT="github.com/celestiaorg/smt"
+export FUZZ_ROOT="github.com/pokt-network/smt"
 
 compile_go_fuzzer "$FUZZ_ROOT"/fuzz Fuzz fuzz_basic_op fuzz
 compile_go_fuzzer "$FUZZ_ROOT"/fuzz/delete Fuzz fuzz_delete fuzz


### PR DESCRIPTION
## Overview

This PR updates the Go version to `1.18` to match `pokt-network/pocket` and also replaces all instances of `celestiaorg` with `pokt-network`

## Checklist

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
