### PR TITLE
feat: Add MultiStore SMT manager

### DIFF
--- a/MultiStore.md
+++ b/MultiStore.md
@@ -1,0 +1,172 @@
+# MultiStore <!-- omit in toc -->
+
+- [Overview](#overview)
+- [Implementation](#implementation)
+	- [MultiStore](#multistore)
+	- [Store](#store)
+- [MultiStore Operations](#multistore-operations)
+	- [Store Creator Functions](#store-creator-functions)
+- [MultiStore Tree Operations](#multistore-tree-operations)
+	- [Commit](#commit)
+	- [Root](#root)
+	- [Prove](#prove)
+- [Store Operations](#store-operations)
+
+## Overview
+
+The `MultiStore` is a wrapper around an SMT that keeps track of and manages numerous different `Store`s. The `MultiStore` contains the name and root hash of each store in its own SMT and allows for the addition of new stores, retrieval of stores, removal of stores and insertion of pre-existing stores. The `MultiStore` interface grants the easy management of numerous different SMTs.
+
+## Implementation
+
+The interface definitions of the `MultiStore` and `Store` wrappers for the SMT can be found in [`types.go`](./types.go)
+
+```go
+// MultiStore is a collection of SMTs managed by a single SMT, this allows for
+// the creation and validation of any SMT managed by the MultiStore being
+// included in the MultiStore as well using the stores individually
+type MultiStore interface {
+	// --- Store operations ---
+
+	// AddStore adds a tree to the MultiStore
+	AddStore(name string, creator func(string, MultiStore) (Store, MapStore)) error
+	// InsertStore adds a pre-existing store into the MultiStore
+	InsertStore(name string, store Store, db MapStore) error
+	// GetStore returns a tree from the MultiStore
+	GetStore(name string) (Store, error)
+	// RemoveStore removes a tree from the MultiStore
+	RemoveStore(name string) error
+Sto
+	// --- Tree operations ---
+
+	// Commit commits all the trees in the MultiStore and the MultiStore itself
+	Commit() error
+	// Root returns the root hash of the MultiStore
+	Root() []byte
+}
+
+// Store is a wrapper around an SMT for use within the MultiStore
+type Store interface {
+	SparseMerkleTree
+	Commit() error
+}
+```
+
+The implementations of both interfaces can be found in [`multi.go`](./multi.go)
+
+### MultiStore
+
+The `MultiStore` interface is implemented by the local `multi` struct. This keeps track of the following fields:
+
+```go
+type multi struct {
+	nodeStore MapStore
+	tree      *SMT
+	storeMap  map[string]Store
+	dbMap     map[string]MapStore
+}
+```
+
+This is in essence an SMT as well as a map of the different SMTs the `MultiStore` tracks, one per name.
+
+### Store
+
+The `Store` interface is implemented by the local `store` struct. This keeps track of the following fields:
+
+```go
+type store struct {
+	*SMT
+	name      string
+	nodeStore MapStore
+	multi     *multi
+}
+```
+
+This is essentially an embedded SMT which also keeps track of the `MultiStore` that it is a part of, as well as its name and underlying database.
+
+## MultiStore Operations
+
+The `MultiStore` interface allows for the following operations:
+
+```go
+// AddStore adds a tree to the MultiStore
+AddStore(name string, creator func(string, MultiStore) (Store, MapStore)) error
+// InsertStore adds a pre-existing store into the MultiStore
+InsertStore(name string, store Store, db MapStore) error
+// GetStore returns a tree from the MultiStore
+GetStore(name string) (Store, error)
+// RemoveStore removes a tree from the MultiStore
+RemoveStore(name string) error
+```
+
+These methods enable:
+
+1. The addition of new `Store`s via the provided creator function
+2. The insertion of pre-existing `Store`s
+3. The retrieval of `Store`s
+4. The removal of `Store`s
+
+### Store Creator Functions
+
+The `Store` creator function enables the customisation of the stores that are added to the `MultiStore`. This enables the use of custom databases (that implement the `MapStore` interface) and custom Tree/Path/Value hashers for the SMT the `Store` wraps.
+
+The creator function must satisfy the following signature:
+
+```go
+func creatorFunc(name string, multi MultiStore) (Store, MapStore)
+```
+
+Where the creator function returns both the wrapped SMT `Store` interface and also the underlying database for the `Store`.
+
+## MultiStore Tree Operations
+
+The `MultiStore` interface also exposes the following operations around its tree:
+
+```go
+// Commit commits all the trees in the MultiStore and the MultiStore itself
+Commit() error
+// Root returns the root hash of the MultiStore
+Root() []byte
+// Prove returns a SparseMerkleProof for the given key from the MultiStore tree
+Prove(key []byte) (*SparseMerkleProof, error)
+```
+
+### Commit
+
+The `Commit` method on the `MultiStore` calls the `Commit` method on the individual `Store`s that the `MultiStore` manages and then calls the `Commit` method of the SMT the `MultiStore` wraps.
+
+The `Store` interface overrides the `Commit` method of the SMT to not only commit the changes from memory to its underlying database but also to update the `MultiStore` it tracks, with the root hash of the `Store` under the key `[]byte(store.name)`.
+
+```mermaid
+graph TB
+    subgraph Store
+        A[Name: example_store]
+        B[Key: foo\nValue: bar]
+        subgraph DB[DB]
+            C[(MapStore)]
+        end
+    end
+    subgraph MultiStore
+        D[Key: example_store\nValue: root_hash]
+        subgraph DB2[DB]
+            E[(MapStore)]
+        end
+    end
+    F[MultiStore] -- Commit --> Store
+    B -- Commit --> C
+    Store -- "example_store\nroot_hash = store.Root()" --> MultiStore
+    D -- Commit --> E
+```
+
+### Root
+
+The `Root` method return the root hash of the tree that the `MultiStore` wraps, this includes the name and root hashes of each of the `Store`s that the `MultiStore` tracks.
+
+### Prove
+
+The `Prove` method generates a `SparseMerkleProof` for the given key from within the tree that the `MultiStore` wraps. This is used to check the inclusion/exclusion of a `Store` within the `MultiStore`, as these are the only values included in the `MultiStore` tree.
+
+## Store Operations
+
+The `Store` interface is a wrapper around an SMT that is managed by a `MultiStore`. The `Store` differes from the SMT it wraps solely in the `Commit` method. This, as mentioned above, is overwritten to not only commit the changes from memory to its underlying database but also to update the `MultiStore` it is tracked by, with the root hash of the `Store` under the key `[]byte(store.name)`.
+
+Other wise all the regular SMT methods work the same with the `Store` interface as they do on a regular SMT.

--- a/README.md
+++ b/README.md
@@ -10,24 +10,25 @@ Note: **Requires Go 1.18+**
 
 - [Overview](#overview)
 - [Implementation](#implementation)
-	- [Inner Nodes](#inner-nodes)
-	- [Extension Nodes](#extension-nodes)
-	- [Leaf Nodes](#leaf-nodes)
-	- [Lazy Nodes](#lazy-nodes)
-	- [Lazy Loading](#lazy-loading)
-	- [Visualisations](#visualisations)
-		- [General Tree Structure](#general-tree-structure)
-		- [Lazy Nodes](#lazy-nodes-1)
+  - [Inner Nodes](#inner-nodes)
+  - [Extension Nodes](#extension-nodes)
+  - [Leaf Nodes](#leaf-nodes)
+  - [Lazy Nodes](#lazy-nodes)
+  - [Lazy Loading](#lazy-loading)
+  - [Visualisations](#visualisations)
+    - [General Tree Structure](#general-tree-structure)
+    - [Lazy Nodes](#lazy-nodes-1)
 - [Paths](#paths)
-	- [Visualisation](#visualisation)
+  - [Visualisation](#visualisation)
 - [Values](#values)
-	- [Nil values](#nil-values)
+  - [Nil values](#nil-values)
 - [Hashers \& Digests](#hashers--digests)
 - [Proofs](#proofs)
-	- [Verification](#verification)
+  - [Verification](#verification)
 - [Database](#database)
-	- [Data Loss](#data-loss)
+  - [Data Loss](#data-loss)
 - [Sparse Merkle Sum Tree](#sparse-merkle-sum-tree)
+- [MultiStore](#multistore)
 - [Example](#example)
 
 ## Overview
@@ -316,6 +317,12 @@ In the event of a system crash or unexpected failure of the program utilising th
 ## Sparse Merkle Sum Tree
 
 This library also implements a Sparse Merkle Sum Tree (SMST), the documentation for which can be found [here](./MerkleSumTree.md).
+
+## MultiStore
+
+The `MultiStore` type is a wrapper around an SMT that allows for the management of multiple SMTs, under a single root hash, while still allowing for their use individually.
+
+See: [MultiStore.md](./MultiStore.md) for more information.
 
 ## Example
 

--- a/multi.go
+++ b/multi.go
@@ -92,6 +92,16 @@ func (m *multi) Root() []byte {
 	return m.tree.Root()
 }
 
+// Prove returns a proof for the given key from the MultiStore
+func (m *multi) Prove(key []byte) (*SparseMerkleProof, error) {
+	return m.tree.Prove(key)
+}
+
+// Spec returns the TreeSpec for the MultiStore tree
+func (m *multi) Spec() *TreeSpec {
+	return m.tree.Spec()
+}
+
 type store struct {
 	*SMT
 	name      string
@@ -102,6 +112,9 @@ type store struct {
 // NewStore creates a new instance of an SMT with the arguments provided and
 // returns the Store wrapper around the SMT and the underlying database
 func NewStore(name string, ms MultiStore, db MapStore, hasher hash.Hash, options ...Option) Store {
+	if _, ok := ms.(*multi); !ok {
+		panic("unable to cast MultiStore")
+	}
 	smt := NewSparseMerkleTree(db, hasher, options...)
 	return &store{
 		SMT:       smt,

--- a/multi_test.go
+++ b/multi_test.go
@@ -1,0 +1,158 @@
+package smt
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMultiStore_AddStore(t *testing.T) {
+	multi := setupMultiStore(t)
+
+	err := multi.AddStore("test", StoreCreator)
+	require.NoError(t, err)
+
+	err = multi.AddStore("test", StoreCreator)
+	require.EqualError(t, err, "store already exists: test")
+}
+
+func TestMultiStore_InsertStore(t *testing.T) {
+	multi := setupMultiStore(t)
+
+	store, db := StoreCreator("test", multi)
+	require.NotNil(t, store)
+	require.NotNil(t, db)
+
+	err := multi.InsertStore("test", store, db)
+	require.NoError(t, err)
+
+	err = multi.InsertStore("test", store, db)
+	require.EqualError(t, err, "store already exists: test")
+}
+
+func TestMultiStore_GetStore(t *testing.T) {
+	multi := setupMultiStore(t)
+
+	err := multi.AddStore("test", StoreCreator)
+	require.NoError(t, err)
+
+	store, err := multi.GetStore("test")
+	require.NoError(t, err)
+	require.NotNil(t, store)
+
+	store, err = multi.GetStore("test2")
+	require.EqualError(t, err, "store not found: test2")
+	require.Nil(t, store)
+}
+
+func TestMultiStore_RemoveStore(t *testing.T) {
+	multi := setupMultiStore(t)
+
+	err := multi.AddStore("test", StoreCreator)
+	require.NoError(t, err)
+
+	err = multi.RemoveStore("test")
+	require.NoError(t, err)
+
+	err = multi.RemoveStore("test")
+	require.EqualError(t, err, "store not found: test")
+}
+
+func TestMultiStore_StoreOperations(t *testing.T) {
+	db := NewSimpleMap()
+	multi := setupMultiStore(t)
+	store, _ := customStoreCreator(t, "test", db, multi)
+
+	// check multi tree empty
+	multiRoot1 := multi.Root()
+	require.Equal(t, hex.EncodeToString(multiRoot1), "0000000000000000000000000000000000000000000000000000000000000000")
+
+	err := store.Update([]byte("foo"), []byte("bar"))
+	require.NoError(t, err)
+
+	// check store root updates
+	root := store.Root()
+	require.Equal(t, hex.EncodeToString(root), "ace64ee83ecf596655deac72c646a30ae7bd71635992cd4c1a5a10350fcc1c52")
+
+	// check insert updates multi tree root
+	err = multi.InsertStore("test", store, db)
+	require.NoError(t, err)
+	multiRoot2 := multi.Root()
+	require.Equal(t, hex.EncodeToString(multiRoot2), "726e2a2b5497e9472b6e6ff5cb5cec0fa145359a130e0e969adf8ada8173c1e4")
+
+	store, err = multi.GetStore("test")
+	require.NoError(t, err)
+
+	err = store.Update([]byte("foo"), []byte("bar2"))
+	require.NoError(t, err)
+
+	// check store root updates
+	root2 := store.Root()
+	require.Equal(t, hex.EncodeToString(root2), "956e81f5c0bb44396fd79c3120c0aef2c2ad0009f3974c0ab7105e01c8ed094f")
+
+	// check multi tree root doesnt update
+	multiRoot3 := multi.Root()
+	require.Equal(t, multiRoot3, multiRoot2)
+
+	// check multi tree root updates after store commits
+	err = store.Commit()
+	require.NoError(t, err)
+	multiRoot4 := multi.Root()
+	require.Equal(t, hex.EncodeToString(multiRoot4), "0175c22dd60ad4db9b1e0bbfd0f7dd8235e4c66b74e04c5282dfbcc895f9085a")
+}
+
+func TestMultiStore_Commit(t *testing.T) {
+	multi := setupMultiStore(t)
+
+	err := multi.AddStore("test", StoreCreator)
+	require.NoError(t, err)
+	err = multi.AddStore("test2", StoreCreator)
+	require.NoError(t, err)
+
+	store, err := multi.GetStore("test")
+	require.NoError(t, err)
+	store2, err := multi.GetStore("test2")
+	require.NoError(t, err)
+
+	// update the stores
+	err = store.Update([]byte("foo"), []byte("bar"))
+	require.NoError(t, err)
+	err = store2.Update([]byte("foo2"), []byte("bar2"))
+	require.NoError(t, err)
+
+	// check store roots update
+	root1 := store.Root()
+	require.Equal(t, hex.EncodeToString(root1), "ace64ee83ecf596655deac72c646a30ae7bd71635992cd4c1a5a10350fcc1c52")
+	root2 := store2.Root()
+	require.Equal(t, hex.EncodeToString(root2), "c8eec74eb4db3fae8caae0e308025fd8027e2303e47c2b9a5cfe63d083e7b689")
+
+	// check multi tree root doesnt update
+	multiRoot1 := multi.Root()
+	require.Equal(t, hex.EncodeToString(multiRoot1), "0000000000000000000000000000000000000000000000000000000000000000")
+
+	// check multi tree root updates after commit
+	err = multi.Commit()
+	require.NoError(t, err)
+	multiRoot2 := multi.Root()
+	require.Equal(t, hex.EncodeToString(multiRoot2), "3b93279b1113300f2d2009a3287b35845fce522c8d3f3f3a81d97388efa54db5")
+}
+
+func setupMultiStore(t *testing.T) MultiStore {
+	t.Helper()
+	db := NewSimpleMap()
+	smt := NewSparseMerkleTree(db, sha256.New())
+	multi := NewMultiStore(db, smt)
+	require.NotNil(t, multi)
+	require.Implements(t, (*MultiStore)(nil), multi)
+	return multi
+}
+
+func customStoreCreator(t *testing.T, name string, db MapStore, multi MultiStore) (Store, MapStore) {
+	t.Helper()
+	store := NewStore(name, multi, db, sha256.New())
+	require.NotNil(t, store)
+	require.Implements(t, (*Store)(nil), store)
+	return store, db
+}

--- a/multi_test.go
+++ b/multi_test.go
@@ -11,11 +11,9 @@ import (
 func TestMultiStore_AddStore(t *testing.T) {
 	multi := setupMultiStore(t)
 
-	err := multi.AddStore("test", StoreCreator)
-	require.NoError(t, err)
+	require.NoError(t, multi.AddStore("test", StoreCreator))
 
-	err = multi.AddStore("test", StoreCreator)
-	require.EqualError(t, err, "store already exists: test")
+	require.EqualError(t, multi.AddStore("test", StoreCreator), "store already exists: test")
 }
 
 func TestMultiStore_InsertStore(t *testing.T) {
@@ -25,18 +23,15 @@ func TestMultiStore_InsertStore(t *testing.T) {
 	require.NotNil(t, store)
 	require.NotNil(t, db)
 
-	err := multi.InsertStore("test", store, db)
-	require.NoError(t, err)
+	require.NoError(t, multi.InsertStore("test", store, db))
 
-	err = multi.InsertStore("test", store, db)
-	require.EqualError(t, err, "store already exists: test")
+	require.EqualError(t, multi.InsertStore("test", store, db), "store already exists: test")
 }
 
 func TestMultiStore_GetStore(t *testing.T) {
 	multi := setupMultiStore(t)
 
-	err := multi.AddStore("test", StoreCreator)
-	require.NoError(t, err)
+	require.NoError(t, multi.AddStore("test", StoreCreator))
 
 	store, err := multi.GetStore("test")
 	require.NoError(t, err)
@@ -50,14 +45,11 @@ func TestMultiStore_GetStore(t *testing.T) {
 func TestMultiStore_RemoveStore(t *testing.T) {
 	multi := setupMultiStore(t)
 
-	err := multi.AddStore("test", StoreCreator)
-	require.NoError(t, err)
+	require.NoError(t, multi.AddStore("test", StoreCreator))
 
-	err = multi.RemoveStore("test")
-	require.NoError(t, err)
+	require.NoError(t, multi.RemoveStore("test"))
 
-	err = multi.RemoveStore("test")
-	require.EqualError(t, err, "store not found: test")
+	require.EqualError(t, multi.RemoveStore("test"), "store not found: test")
 }
 
 func TestMultiStore_StoreOperations(t *testing.T) {
@@ -69,24 +61,21 @@ func TestMultiStore_StoreOperations(t *testing.T) {
 	multiRoot1 := multi.Root()
 	require.Equal(t, hex.EncodeToString(multiRoot1), "0000000000000000000000000000000000000000000000000000000000000000")
 
-	err := store.Update([]byte("foo"), []byte("bar"))
-	require.NoError(t, err)
+	require.NoError(t, store.Update([]byte("foo"), []byte("bar")))
 
 	// check store root updates
 	root := store.Root()
 	require.Equal(t, hex.EncodeToString(root), "ace64ee83ecf596655deac72c646a30ae7bd71635992cd4c1a5a10350fcc1c52")
 
 	// check insert updates multi tree root
-	err = multi.InsertStore("test", store, db)
-	require.NoError(t, err)
+	require.NoError(t, multi.InsertStore("test", store, db))
 	multiRoot2 := multi.Root()
 	require.Equal(t, hex.EncodeToString(multiRoot2), "726e2a2b5497e9472b6e6ff5cb5cec0fa145359a130e0e969adf8ada8173c1e4")
 
-	store, err = multi.GetStore("test")
+	store, err := multi.GetStore("test")
 	require.NoError(t, err)
 
-	err = store.Update([]byte("foo"), []byte("bar2"))
-	require.NoError(t, err)
+	require.NoError(t, store.Update([]byte("foo"), []byte("bar2")))
 
 	// check store root updates
 	root2 := store.Root()
@@ -97,8 +86,7 @@ func TestMultiStore_StoreOperations(t *testing.T) {
 	require.Equal(t, multiRoot3, multiRoot2)
 
 	// check multi tree root updates after store commits
-	err = store.Commit()
-	require.NoError(t, err)
+	require.NoError(t, store.Commit())
 	multiRoot4 := multi.Root()
 	require.Equal(t, hex.EncodeToString(multiRoot4), "0175c22dd60ad4db9b1e0bbfd0f7dd8235e4c66b74e04c5282dfbcc895f9085a")
 }
@@ -106,10 +94,8 @@ func TestMultiStore_StoreOperations(t *testing.T) {
 func TestMultiStore_Commit(t *testing.T) {
 	multi := setupMultiStore(t)
 
-	err := multi.AddStore("test", StoreCreator)
-	require.NoError(t, err)
-	err = multi.AddStore("test2", StoreCreator)
-	require.NoError(t, err)
+	require.NoError(t, multi.AddStore("test", StoreCreator))
+	require.NoError(t, multi.AddStore("test2", StoreCreator))
 
 	store, err := multi.GetStore("test")
 	require.NoError(t, err)
@@ -117,10 +103,8 @@ func TestMultiStore_Commit(t *testing.T) {
 	require.NoError(t, err)
 
 	// update the stores
-	err = store.Update([]byte("foo"), []byte("bar"))
-	require.NoError(t, err)
-	err = store2.Update([]byte("foo2"), []byte("bar2"))
-	require.NoError(t, err)
+	require.NoError(t, store.Update([]byte("foo"), []byte("bar")))
+	require.NoError(t, store2.Update([]byte("foo2"), []byte("bar2")))
 
 	// check store roots update
 	root1 := store.Root()
@@ -133,10 +117,37 @@ func TestMultiStore_Commit(t *testing.T) {
 	require.Equal(t, hex.EncodeToString(multiRoot1), "0000000000000000000000000000000000000000000000000000000000000000")
 
 	// check multi tree root updates after commit
-	err = multi.Commit()
-	require.NoError(t, err)
+	require.NoError(t, multi.Commit())
 	multiRoot2 := multi.Root()
 	require.Equal(t, hex.EncodeToString(multiRoot2), "3b93279b1113300f2d2009a3287b35845fce522c8d3f3f3a81d97388efa54db5")
+}
+
+func TestMultiStore_Prove(t *testing.T) {
+	multi := setupMultiStore(t)
+
+	require.NoError(t, multi.AddStore("test", StoreCreator))
+
+	store, err := multi.GetStore("test")
+	require.NoError(t, err)
+
+	// update the store
+	require.NoError(t, store.Update([]byte("foo"), []byte("bar")))
+	root1 := store.Root()
+	require.Equal(t, hex.EncodeToString(root1), "ace64ee83ecf596655deac72c646a30ae7bd71635992cd4c1a5a10350fcc1c52")
+	require.NoError(t, store.Commit())
+
+	// generate proof
+	proof, err := multi.Prove([]byte("test"))
+	require.NoError(t, err)
+	require.NotNil(t, proof)
+
+	// verify proof
+	valid := VerifyProof(proof, multi.Root(), []byte("test"), root1, multi.Spec())
+	require.True(t, valid)
+	invalid := VerifyProof(proof, multi.Root(), []byte("test"), []byte("foo"), multi.Spec())
+	require.False(t, invalid)
+	invalid = VerifyProof(proof, multi.Root(), []byte("test"), nil, multi.Spec())
+	require.False(t, invalid)
 }
 
 func setupMultiStore(t *testing.T) MultiStore {

--- a/mutli.go
+++ b/mutli.go
@@ -1,0 +1,112 @@
+package smt
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+)
+
+var (
+	_ MultiStore = (*multi)(nil)
+	_ Store      = (*store)(nil)
+
+	// StoreCreator is a function that creates a new Store for the given MultiStore
+	StoreCreator = func(name string, ms MultiStore) (Store, MapStore) {
+		db := NewSimpleMap()
+		return NewStore(name, ms, db, sha256.New()), db
+	}
+)
+
+type multi struct {
+	nodeStore MapStore
+	tree      *SMT
+	storeMap  map[string]Store
+	dbMap     map[string]MapStore
+}
+
+// NewMultiStore creates a new instance of the MultiStore
+func NewMultiStore(db MapStore, smt *SMT) MultiStore {
+	return &multi{
+		nodeStore: db,
+		tree:      smt,
+		storeMap:  make(map[string]Store, 0),
+		dbMap:     make(map[string]MapStore, 0),
+	}
+}
+
+// AddStore adds a store to the MultiStore using the store creator function provided
+func (m *multi) AddStore(name string, creator func(name string, ms MultiStore) (Store, MapStore)) error {
+	if _, ok := m.storeMap[name]; ok {
+		return fmt.Errorf("store already exists: %s", name)
+	}
+	store, db := creator(name, m)
+	m.storeMap[name] = store
+	m.dbMap[name] = db
+	return nil
+}
+
+// GetStore returns a store from the MultiStore
+func (m *multi) GetStore(name string) (Store, error) {
+	if store, ok := m.storeMap[name]; ok {
+		return store, nil
+	}
+	return nil, fmt.Errorf("store not found: %s", name)
+}
+
+// RemoveStore removes a store from the MultiStore
+func (m *multi) RemoveStore(name string) error {
+	if _, ok := m.storeMap[name]; !ok {
+		return fmt.Errorf("store not found: %s", name)
+	}
+	delete(m.storeMap, name)
+	delete(m.dbMap, name)
+	return nil
+}
+
+// Commit calls commit on each of the stores tracked by the MultiStore
+// which updates the MutliStore to contain their root hashes and then
+// commits its own tree to the underlying database
+func (m *multi) Commit() error {
+	for _, store := range m.storeMap {
+		if err := store.Commit(); err != nil {
+			return err
+		}
+	}
+	return m.Commit()
+}
+
+// Root returns the root hash of the MultiStore
+func (m *multi) Root() []byte {
+	return m.tree.Root()
+}
+
+type store struct {
+	*SMT
+	name      string
+	nodeStore MapStore
+	multi     *multi
+}
+
+// NewStore creates a new instance of an SMT with the arguments provided and
+// returns the Store wrapper around the SMT and the underlying database
+func NewStore(name string, ms MultiStore, db MapStore, hasher hash.Hash, options ...Option) Store {
+	smt := NewSparseMerkleTree(db, hasher, options...)
+	return &store{
+		SMT:       smt,
+		name:      name,
+		nodeStore: db,
+		multi:     ms.(*multi),
+	}
+}
+
+// Commit commits any changes to the underlying database and
+// also updates the MultiStore to include its latest root hash
+func (s *store) Commit() error {
+	if err := s.SMT.Commit(); err != nil {
+		return fmt.Errorf("failed to commit store (%s): %w", s.name, err)
+	}
+	if err := s.multi.tree.Update([]byte(s.name), s.Root()); err != nil {
+		return fmt.Errorf("failed to update multi tree (%s): %w", s.name, err)
+	}
+	return nil
+}

--- a/types.go
+++ b/types.go
@@ -56,6 +56,33 @@ type SparseMerkleSumTree interface {
 	Spec() *TreeSpec
 }
 
+// MultiStore is a collection of SMTs managed by a single SMT, this allows for
+// the creation and validation of any SMT managed by the MultiStore being
+// included in the MultiStore as well using the stores individually
+type MultiStore interface {
+	// --- Store operations ---
+
+	// AddStore adds a tree to the MultiStore
+	AddStore(name string, creator func(string, MultiStore) (Store, MapStore)) error
+	// GetStore returns a tree from the MultiStore
+	GetStore(name string) (Store, error)
+	// RemoveStore removes a tree from the MultiStore
+	RemoveStore(name string) error
+
+	// --- Store operations ---
+
+	// Commit commits all the trees in the MultiStore and the MultiStore itself
+	Commit() error
+	// Root returns the root hash of the MultiStore
+	Root() []byte
+}
+
+// Store is a wrapper around an SMT for use within the MultiStore
+type Store interface {
+	SparseMerkleTree
+	Commit() error
+}
+
 // TreeSpec specifies the hashing functions used by a tree instance to encode leaf paths
 // and stored values, and the corresponding maximum tree depth.
 type TreeSpec struct {

--- a/types.go
+++ b/types.go
@@ -64,6 +64,8 @@ type MultiStore interface {
 
 	// AddStore adds a tree to the MultiStore
 	AddStore(name string, creator func(string, MultiStore) (Store, MapStore)) error
+	// InsertStore adds a pre-existing store into the MutliStore
+	InsertStore(name string, store Store, db MapStore) error
 	// GetStore returns a tree from the MultiStore
 	GetStore(name string) (Store, error)
 	// RemoveStore removes a tree from the MultiStore

--- a/types.go
+++ b/types.go
@@ -71,12 +71,16 @@ type MultiStore interface {
 	// RemoveStore removes a tree from the MultiStore
 	RemoveStore(name string) error
 
-	// --- Store operations ---
+	// --- Tree operations ---
 
 	// Commit commits all the trees in the MultiStore and the MultiStore itself
 	Commit() error
 	// Root returns the root hash of the MultiStore
 	Root() []byte
+	// Prove returns a SparseMerkleProof for the given key from the MultiStore tree
+	Prove(key []byte) (*SparseMerkleProof, error)
+	// Spec returns the TreeSpec for the MultiStore tree
+	Spec() *TreeSpec
 }
 
 // Store is a wrapper around an SMT for use within the MultiStore


### PR DESCRIPTION
## Description

This PR introduces the new `MultiStore` SMT manager. This enables the management of numerous SMTs under a single overarching tree.

The `MultiStore` acts as a wrapper around an SMT that includes the name and root hash of the trees it manages. The `Store` interface is a wrapper around a single SMT which tracks the `MultiStore` it is a part of and overwrites the SMT's `Commit` method to not only commit the `Store`'s changes to the database but also update the `MultiStore` with the name and root hash of the `Store`'s tree.

This is useful in areas where a single tree / root hash is needed but different SMT's are desired: for example in a blockchain setting this could replace the root tree and each of the trees it manages could track the transactions, accounts etc. It would also be useful for an implementation of the IBC specification where the `MultiStore` would represent the IBC store as a whole with each `Store` representing a single ICS component such as the ICS-02 store or the ICS-03 store.

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 31 Jul 23 12:52 UTC
This pull request introduces significant changes to several files related to the `MultiStore` functionality. Here is a summary of the changes:

1. `multi_test.go`: The file now includes test functions and helper functions for testing the `MultiStore` functionality. The test functions cover various operations such as adding a store, inserting a pre-existing store, getting a store, removing a store, performing store operations, committing changes, and generating proofs. Additionally, a helper function `customStoreCreator` is added.

2. `multi.go`: This file implements the `MultiStore` interface and its associated functions. The `multi` struct represents a collection of multiple stores and implements methods such as `AddStore`, `InsertStore`, `GetStore`, `RemoveStore`, `Commit`, `Root`, `Prove`, and `Spec`. The `store` struct represents an individual store within the `MultiStore`, maintaining a reference to the parent `MultiStore` and implementing a `Commit` method that updates the multi-store with the latest root hash.

3. `MultiStore.md`: The Markdown file provides an overview of the `MultiStore` interface and its functionalities. It explains how the `MultiStore` manages multiple stores and describes the operations available for managing stores and trees. It also introduces the `Store` type, which is a wrapper around an `SMT` and includes a `Commit` method to update the multi-store with the root hash of the store. Additionally, it discusses the `TreeSpec` type, which specifies the hashing functions and maximum depth of the tree.

These changes significantly enhance the functionality and usage of the `MultiStore` concept, allowing for better management and manipulation of multiple stores within the system.
<!-- reviewpad:summarize:end -->

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Major breaking change
- [ ] Documentation
- [ ] Other <!-- add details here if it a different type of change -->

## List of changes

- Add the `MultiStore` and `Store` interfaces
- Add the `multi` and `store` structs to implement the interfaces
- Add unit tests
- Add documentation

## Testing

- [x] **Task specific tests or benchmarks**: `go test ...`
- [x] **New tests or benchmarks**: `go test ...`
- [x] **All tests**: `go test -v`

## Required Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added, or updated, [`godoc` format comments](https://go.dev/blog/godoc) on touched members (see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))
- [x] I have tested my changes using the available tooling

### If Applicable Checklist

- [x] Update any relevant README(s)
- [x] Add or update any relevant or supporting [mermaid](https://mermaid-js.github.io/mermaid/) diagrams
- [x] I have added tests that prove my fix is effective or that my feature works
