### PR TITLE
[Bug] Fix bug introduced by changing `BigEndian` to `LittleEndian`

### DIFF
--- a/benchmarks/proof_sizes_test.go
+++ b/benchmarks/proof_sizes_test.go
@@ -43,7 +43,7 @@ func TestSMT_ProofSizes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for i := 0; i < tc.trieSize; i++ {
 				b := make([]byte, 8)
-				binary.LittleEndian.PutUint64(b, uint64(i))
+				binary.BigEndian.PutUint64(b, uint64(i))
 				require.NoError(t, trie.Update(b, b))
 			}
 			require.NoError(t, trie.Commit())
@@ -55,7 +55,7 @@ func TestSMT_ProofSizes(t *testing.T) {
 			minCompact := uint64(0)
 			for i := 0; i < tc.trieSize; i++ {
 				b := make([]byte, 8)
-				binary.LittleEndian.PutUint64(b, uint64(i))
+				binary.BigEndian.PutUint64(b, uint64(i))
 				proof, err := trie.Prove(b)
 				require.NoError(t, err)
 				require.NotNil(t, proof)
@@ -132,7 +132,7 @@ func TestSMST_ProofSizes(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			for i := 0; i < tc.trieSize; i++ {
 				b := make([]byte, 8)
-				binary.LittleEndian.PutUint64(b, uint64(i))
+				binary.BigEndian.PutUint64(b, uint64(i))
 				require.NoError(t, trie.Update(b, b, uint64(i)))
 			}
 			require.NoError(t, trie.Commit())
@@ -144,7 +144,7 @@ func TestSMST_ProofSizes(t *testing.T) {
 			minCompact := uint64(0)
 			for i := 0; i < tc.trieSize; i++ {
 				b := make([]byte, 8)
-				binary.LittleEndian.PutUint64(b, uint64(i))
+				binary.BigEndian.PutUint64(b, uint64(i))
 				proof, err := trie.Prove(b)
 				require.NoError(t, err)
 				require.NotNil(t, proof)

--- a/docs/MerkleSumTrie.md
+++ b/docs/MerkleSumTrie.md
@@ -61,7 +61,7 @@ The majority of the code relating to the SMST can be found in:
 The sum for any node is encoded in a byte array with a fixed size (`[8]byte`)
 this allows for the sum to fully represent a `uint64` value in binary form.
 The golang `encoding/binary` package is used to encode the sum with
-`binary.LittleEndian.PutUint64(sumBz[:], sum)` into a byte array `sumBz`.
+`binary.BigEndian.PutUint64(sumBz[:], sum)` into a byte array `sumBz`.
 
 In order for the SMST to include the sum into a leaf node the SMT the SMST
 initialises the SMT with the `WithValueHasher(nil)` option so that the SMT does

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -72,7 +72,7 @@ func FuzzSMT_DetectUnexpectedFailures(f *testing.F) {
 				require.Equal(t, originalRoot, newRoot, "root changed while getting")
 			case Update:
 				value := make([]byte, 32)
-				binary.LittleEndian.PutUint64(value, uint64(i))
+				binary.BigEndian.PutUint64(value, uint64(i))
 				err := trie.Update(key(), value)
 				require.NoErrorf(t, err, "unknown error occured while updating")
 				newRoot := trie.Root()
@@ -93,6 +93,8 @@ func FuzzSMT_DetectUnexpectedFailures(f *testing.F) {
 				}
 				newRoot := trie.Root()
 				require.Equal(t, originalRoot, newRoot, "root changed while proving")
+			default:
+				panic("unknown operation")
 			}
 
 			newRoot := trie.Root()

--- a/hasher.go
+++ b/hasher.go
@@ -167,12 +167,12 @@ func encodeSumInner(leftData []byte, rightData []byte) []byte {
 	leftSumBz := leftData[len(leftData)-sumSize:]
 	rightSumBz := rightData[len(rightData)-sumSize:]
 	if !bytes.Equal(leftSumBz, defaultSum[:]) {
-		leftSum = binary.LittleEndian.Uint64(leftSumBz)
+		leftSum = binary.BigEndian.Uint64(leftSumBz)
 	}
 	if !bytes.Equal(rightSumBz, defaultSum[:]) {
-		rightSum = binary.LittleEndian.Uint64(rightSumBz)
+		rightSum = binary.BigEndian.Uint64(rightSumBz)
 	}
-	binary.LittleEndian.PutUint64(sum[:], leftSum+rightSum)
+	binary.BigEndian.PutUint64(sum[:], leftSum+rightSum)
 	value = append(value, sum[:]...)
 	return value
 }

--- a/proofs.go
+++ b/proofs.go
@@ -285,7 +285,7 @@ func VerifyProof(proof *SparseMerkleProof, root, key, value []byte, spec *TrieSp
 // VerifySumProof verifies a Merkle proof for a sum trie.
 func VerifySumProof(proof *SparseMerkleProof, root, key, value []byte, sum uint64, spec *TrieSpec) (bool, error) {
 	var sumBz [sumSize]byte
-	binary.LittleEndian.PutUint64(sumBz[:], sum)
+	binary.BigEndian.PutUint64(sumBz[:], sum)
 	valueHash := spec.digestValue(value)
 	valueHash = append(valueHash, sumBz[:]...)
 	if bytes.Equal(value, defaultValue) && sum == 0 {
@@ -318,7 +318,7 @@ func VerifyClosestProof(proof *SparseMerkleClosestProof, root []byte, spec *Trie
 		return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, nil, 0, spec)
 	}
 	sumBz := proof.ClosestValueHash[len(proof.ClosestValueHash)-sumSize:]
-	sum := binary.LittleEndian.Uint64(sumBz)
+	sum := binary.BigEndian.Uint64(sumBz)
 	valueHash := proof.ClosestValueHash[:len(proof.ClosestValueHash)-sumSize]
 	return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, valueHash, sum, spec)
 }

--- a/proofs_test.go
+++ b/proofs_test.go
@@ -193,13 +193,9 @@ func randomiseSumProof(proof *SparseMerkleProof) *SparseMerkleProof {
 func checkCompactEquivalence(t *testing.T, proof *SparseMerkleProof, base *TrieSpec) {
 	t.Helper()
 	compactedProof, err := CompactProof(proof, base)
-	if err != nil {
-		t.Fatalf("failed to compact proof: %v", err)
-	}
+	require.NoErrorf(t, err, "failed to compact proof: %v", err)
 	decompactedProof, err := DecompactProof(compactedProof, base)
-	if err != nil {
-		t.Fatalf("failed to decompact proof: %v", err)
-	}
+	require.NoErrorf(t, err, "failed to decompact proof: %v", err)
 	require.Equal(t, proof, decompactedProof)
 }
 
@@ -207,12 +203,8 @@ func checkCompactEquivalence(t *testing.T, proof *SparseMerkleProof, base *TrieS
 func checkClosestCompactEquivalence(t *testing.T, proof *SparseMerkleClosestProof, spec *TrieSpec) {
 	t.Helper()
 	compactedProof, err := CompactClosestProof(proof, spec)
-	if err != nil {
-		t.Fatalf("failed to compact proof: %v", err)
-	}
+	require.NoErrorf(t, err, "failed to compact proof: %v", err)
 	decompactedProof, err := DecompactClosestProof(compactedProof, spec)
-	if err != nil {
-		t.Fatalf("failed to decompact proof: %v", err)
-	}
+	require.NoErrorf(t, err, "failed to decompact proof: %v", err)
 	require.Equal(t, proof, decompactedProof)
 }

--- a/smst.go
+++ b/smst.go
@@ -59,7 +59,7 @@ func (smst *SMST) Get(key []byte) ([]byte, uint64, error) {
 	}
 	var weightBz [sumSize]byte
 	copy(weightBz[:], valueHash[len(valueHash)-sumSize:])
-	weight := binary.LittleEndian.Uint64(weightBz[:])
+	weight := binary.BigEndian.Uint64(weightBz[:])
 	return valueHash[:len(valueHash)-sumSize], weight, nil
 }
 
@@ -69,7 +69,7 @@ func (smst *SMST) Get(key []byte) ([]byte, uint64, error) {
 func (smst *SMST) Update(key, value []byte, weight uint64) error {
 	valueHash := smst.digestValue(value)
 	var weightBz [sumSize]byte
-	binary.LittleEndian.PutUint64(weightBz[:], weight)
+	binary.BigEndian.PutUint64(weightBz[:], weight)
 	valueHash = append(valueHash, weightBz[:]...)
 	return smst.SMT.Update(key, valueHash)
 }
@@ -109,5 +109,5 @@ func (smst *SMST) Sum() uint64 {
 	var sumBz [sumSize]byte
 	digest := smst.Root()
 	copy(sumBz[:], digest[len(digest)-sumSize:])
-	return binary.LittleEndian.Uint64(sumBz[:])
+	return binary.BigEndian.Uint64(sumBz[:])
 }

--- a/smst_proofs_test.go
+++ b/smst_proofs_test.go
@@ -101,7 +101,7 @@ func TestSMST_Proof_Operations(t *testing.T) {
 
 	// Try proving a default value for a non-default leaf.
 	var sum [sumSize]byte
-	binary.LittleEndian.PutUint64(sum[:], 5)
+	binary.BigEndian.PutUint64(sum[:], 5)
 	tval := base.digestValue([]byte("testValue"))
 	tval = append(tval, sum[:]...)
 	_, leafData := base.th.digestSumLeaf(base.ph.Path([]byte("testKey2")), tval)
@@ -321,7 +321,7 @@ func TestSMST_ProveClosest(t *testing.T) {
 	require.NotEqual(t, proof, &SparseMerkleClosestProof{})
 	closestPath := sha256.Sum256([]byte("testKey2"))
 	closestValueHash := []byte("testValue2")
-	binary.LittleEndian.PutUint64(sumBz[:], 24)
+	binary.BigEndian.PutUint64(sumBz[:], 24)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path[:],
@@ -347,7 +347,7 @@ func TestSMST_ProveClosest(t *testing.T) {
 	require.NotEqual(t, proof, &SparseMerkleClosestProof{})
 	closestPath = sha256.Sum256([]byte("testKey4"))
 	closestValueHash = []byte("testValue4")
-	binary.LittleEndian.PutUint64(sumBz[:], 30)
+	binary.BigEndian.PutUint64(sumBz[:], 30)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path2[:],
@@ -418,7 +418,7 @@ func TestSMST_ProveClosest_OneNode(t *testing.T) {
 	closestPath := sha256.Sum256([]byte("foo"))
 	closestValueHash := []byte("bar")
 	var sumBz [sumSize]byte
-	binary.LittleEndian.PutUint64(sumBz[:], 5)
+	binary.BigEndian.PutUint64(sumBz[:], 5)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path[:],
@@ -450,8 +450,8 @@ func TestSMST_ProveClosest_Proof(t *testing.T) {
 	smst256 = NewSparseMerkleSumTrie(smn, sha256.New())
 	smst512 = NewSparseMerkleSumTrie(smn, sha512.New())
 
-	// insert 100000 key-value-sum triples
-	for i := 0; i < 100000; i++ {
+	// insert 100 key-value-sum triples
+	for i := 0; i < 100; i++ {
 		s := strconv.Itoa(i)
 		require.NoError(t, smst256.Update([]byte(s), []byte(s), uint64(i)))
 		require.NoError(t, smst512.Update([]byte(s), []byte(s), uint64(i)))

--- a/smst_test.go
+++ b/smst_test.go
@@ -460,7 +460,7 @@ func TestSMST_TotalSum(t *testing.T) {
 	// Check root hash contains the correct hex sum
 	root1 := smst.Root()
 	sumBz := root1[len(root1)-sumSize:]
-	rootSum := binary.LittleEndian.Uint64(sumBz)
+	rootSum := binary.BigEndian.Uint64(sumBz)
 	require.NoError(t, err)
 
 	// Calculate total sum of the trie

--- a/smt_proofs_test.go
+++ b/smt_proofs_test.go
@@ -400,8 +400,8 @@ func TestSMT_ProveClosest_Proof(t *testing.T) {
 	smt256 = NewSparseMerkleTrie(smn, sha256.New())
 	smt512 = NewSparseMerkleTrie(smn, sha512.New())
 
-	// insert 100000 key-value-sum triples
-	for i := 0; i < 100000; i++ {
+	// insert 100 key-value-sum triples
+	for i := 0; i < 100; i++ {
 		s := strconv.Itoa(i)
 		require.NoError(t, smt256.Update([]byte(s), []byte(s)))
 		require.NoError(t, smt512.Update([]byte(s), []byte(s)))

--- a/utils.go
+++ b/utils.go
@@ -103,7 +103,7 @@ func minBytes(i int) int {
 // intToBytes converts an int to a byte slice
 func intToBytes(i int) []byte {
 	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, uint64(i))
+	binary.BigEndian.PutUint64(b, uint64(i))
 	d := minBytes(i)
 	return b[8-d:]
 }
@@ -113,7 +113,7 @@ func bytesToInt(bz []byte) int {
 	b := make([]byte, 8) // allocate space for a 64-bit unsigned integer
 	d := 8 - len(bz)     // determine how much padding is necessary
 	copy(b[d:], bz)      // copy over the non-zero bytes
-	u := binary.LittleEndian.Uint64(b)
+	u := binary.BigEndian.Uint64(b)
 	return int(u)
 }
 


### PR DESCRIPTION
## Summary

### Human Summary

- When `BigEndian` what changed to `LittleEndian` it meant that the hashes generated by the trie would be different in the SMST
- This meant that for the ProveClosest method where hardcoded hashes were used they broke
- This change reverts this among other minor fixes

### AI Summary

<!-- reviewpad:summarize:start -->
### Summary generated by Reviewpad on 01 Jan 24 20:51 UTC
This pull request includes the following changes:

1. The file `proof_sizes_test.go` has updates related to modifying and proving values in a trie data structure. It includes replacing the usage of `binary.LittleEndian.PutUint64` with `binary.BigEndian.PutUint64`.

2. The file `smst_proofs_test.go` has changes in lines 101, 321, 347, 418, and 450, where `binary.LittleEndian.PutUint64` is replaced with `binary.BigEndian.PutUint64`. Additionally, the loop in line 450 has been modified to insert 100 key-value-sum triples instead of 100,000.

3. The file `smst_utils_test.go` has changes in the `Update` and `GetValueSum` functions. The byte order used for encoding and decoding the `sumBz` variable has been modified from little endian to big endian. The `ProveSumCompact` function has been removed.

4. The file `smst.go` has changes in the `Get`, `Update`, and `Sum` functions, where the byte ordering of variables `weight` and `sum` has been changed from little endian to big endian.

5. The file `smst_test.go` has a change in line 462, where `binary.LittleEndian.Uint64` is replaced with `binary.BigEndian.Uint64` for calculating the variable `rootSum`.

6. The file diff includes modifications in functions related to compaction and decompaction in the `smt_proofs_test.go` file. The error handling has been improved by replacing `t.Fatalf()` with `require.NoErrorf()`.

7. The file diff modifies the test case `TestSMT_ProveClosest_Proof` in `smt_proofs_test.go`, reducing the number of key-value-sum triples inserted from 100,000 to 100.

8. The file `utils.go` has changes in the `intToBytes` and `bytesToInt` functions. The byte ordering for converting between int and byte slice has been changed from little endian to big endian.

9. The file `proofs.go` has changes in the `VerifyProof` and `VerifyClosestProof` functions, where the byte ordering for encoding and decoding a uint64 value has been changed from little endian to big endian.

10. The file `hasher.go` has changes in the `encodeSumInner` function. The byte slices are now converted into unsigned integers and sum using big endian encoding instead of little endian encoding.

11. The file `fuzz_test.go` has changes in line 75, replacing `binary.LittleEndian.PutUint64` with `binary.BigEndian.PutUint64`, and lines 96-98, where a default case has been added to handle unknown operations.

12. The file diff in `MerkleSumTrie.md` suggests changing the encoding of the sum value from little endian to big endian.

Let me know if you need any further assistance!
<!-- reviewpad:summarize:end -->

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [x] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)


## Testing

- [x] **Run all unit tests**: `make test_all`
- [ ] **Run all/relevant benchmarks (if optimising)**: `make benchmark_{all | suite name}`

<!-- REMOVE this comment block after following the instructions
 If you added additional tests or infrastructure, describe it here.
 Bonus points for images and videos or gifs.
-->

## Required Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code ([`godoc` format comments](https://go.dev/blog/godoc) see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))

### If Applicable Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated any relevant README(s)/documentation and left TODOs throughout the codebase
- [ ] Add or update any relevant or supporting [mermaid](https://mermaid-js.github.io/mermaid/) diagrams
