### PR TITLE
[Enhancement] Add features related to the usage of the `ClosestProof` method

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,4 +9,7 @@ var (
 	ErrBadProof = errors.New("bad proof")
 	// ErrKeyNotFound is returned when a key is not found in the tree.
 	ErrKeyNotFound = errors.New("key not found")
+	// ErrInvalidClosestPath is returned when the path used in the ClosestProof
+	// method does not match the size of the trie's PathHasher
+	ErrInvalidClosestPath = errors.New("invalid path does not match path hasher size")
 )

--- a/hasher.go
+++ b/hasher.go
@@ -29,6 +29,8 @@ type PathHasher interface {
 type ValueHasher interface {
 	// HashValue hashes value data to produce the digest stored in leaf node.
 	HashValue([]byte) []byte
+	// ValueHashSize returns the length (in bytes) of digests produced by this hasher.
+	ValueHashSize() int
 }
 
 type trieHasher struct {
@@ -59,8 +61,17 @@ func (ph *pathHasher) PathSize() int {
 	return ph.hasher.Size()
 }
 
+// HashValue hashes the producdes a digest of the data provided by the value hasher
 func (vh *valueHasher) HashValue(data []byte) []byte {
 	return vh.digest(data)
+}
+
+// ValueHashSize returns the length (in bytes) of digests produced by the value hasher
+func (vh *valueHasher) ValueHashSize() int {
+	if vh.hasher == nil {
+		return 0
+	}
+	return vh.hasher.Size()
 }
 
 func (th *trieHasher) digest(data []byte) []byte {

--- a/proofs.go
+++ b/proofs.go
@@ -186,6 +186,12 @@ func (proof *SparseMerkleClosestProof) Unmarshal(bz []byte) error {
 }
 
 func (proof *SparseMerkleClosestProof) validateBasic(spec *TrieSpec) error {
+	// ensure the proof length is the same size (in bytes) as the path
+	// hasher of the spec provided
+	if len(proof.Path) != spec.PathHasherSize() {
+		return fmt.Errorf("invalid path length: got %d, want %d", len(proof.Path), spec.PathHasherSize())
+	}
+
 	// ensure the depth of the leaf node being proven is within the path size
 	if proof.Depth < 0 || proof.Depth > spec.ph.PathSize()*8 {
 		return fmt.Errorf("invalid depth: got %d, outside of [0, %d]", proof.Depth, spec.ph.PathSize()*8)
@@ -231,6 +237,12 @@ type SparseCompactMerkleClosestProof struct {
 }
 
 func (proof *SparseCompactMerkleClosestProof) validateBasic(spec *TrieSpec) error {
+	// Ensure the proof length is the same size (in bytes) as the path
+	// hasher of the spec provided
+	if len(proof.Path) != spec.PathHasherSize() {
+		return fmt.Errorf("invalid path length: got %d, want %d", len(proof.Path), spec.PathHasherSize())
+	}
+
 	// Do a basic sanity check on the proof on the fields of the proof specific to
 	// the compact proof only.
 	//

--- a/smt.go
+++ b/smt.go
@@ -407,6 +407,11 @@ func (smt *SMT) ProveClosest(path []byte) (
 	proof *SparseMerkleClosestProof, // proof of the key-value pair found
 	err error, // the error value encountered
 ) {
+	// Ensure the path provided is the correct length for the path hasher.
+	if len(path) != smt.Spec().PathHasherSize() {
+		return nil, ErrInvalidClosestPath
+	}
+
 	workingPath := make([]byte, len(path))
 	copy(workingPath, path)
 	var siblings []trieNode

--- a/types.go
+++ b/types.go
@@ -98,6 +98,18 @@ func newTrieSpec(hasher hash.Hash, sumTrie bool) TrieSpec {
 // Spec returns the TrieSpec associated with the given trie
 func (spec *TrieSpec) Spec() *TrieSpec { return spec }
 
+// PathHasherSize returns the length (in bytes) of digests produced by the
+// path hasher
+func (spec *TrieSpec) PathHasherSize() int { return spec.ph.PathSize() }
+
+// ValueHasherSize returns the length (in bytes) of digests produced by the
+// value hasher
+func (spec *TrieSpec) ValueHasherSize() int { return spec.vh.ValueHashSize() }
+
+// TrieHasherSize returns the length (in bytes) of digests produced by the
+// trie hasher
+func (spec *TrieSpec) TrieHasherSize() int { return spec.th.hashSize() }
+
 func (spec *TrieSpec) depth() int { return spec.ph.PathSize() * 8 }
 func (spec *TrieSpec) digestValue(data []byte) []byte {
 	if spec.vh == nil {


### PR DESCRIPTION
## Summary

### Human Summary

- Adds `GetValueHash` to `SparseMerkleClosestProof` type
- Adds to the `TrieSpec` (from `sm(s)t.Spec()`):
  - `PathHasherSize()`
  - `ValueHasherSize()`
  - `TrieHasherSize()`
  - **All measured in bytes**
- Enforces that the path passed into `ClosestProof` and the `Proof` field of the `SparseMerkle(Compact)ClosestProof` types is the same length as the spec's `PathHasherSize()`

### AI Summary

reviewpad:summary

## Issue

Fixes N/A

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)


## Testing

- [x] **Run all unit tests**: `make test_all`
- [ ] **Run all/relevant benchmarks (if optimising)**: `make benchmark_{all | suite name}`

## Required Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [x] I have commented my code ([`godoc` format comments](https://go.dev/blog/godoc) see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))

### If Applicable Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated any relevant README(s)/documentation and left TODOs throughout the codebase
- [ ] Add or update any relevant or supporting [mermaid](https://mermaid-js.github.io/mermaid/) diagrams
