### PR TITLE
[Leaf Counter] Adding a cryptographically secure non-empty leaf counter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/sh
+
 .SILENT:
 
 #####################
@@ -61,31 +63,31 @@ go_docs: check_godoc ## Generate documentation for the project
 
 .PHONY: benchmark_all
 benchmark_all:  ## runs all benchmarks
-	go test -tags=benchmark -benchmem -run=^$ -bench Benchmark ./benchmarks -timeout 0
+	go test -tags=benchmark -benchmem -run=^$$ -bench Benchmark ./benchmarks -timeout 0
 
 .PHONY: benchmark_smt
 benchmark_smt:  ## runs all benchmarks for the SMT
-	go test -tags=benchmark -benchmem -run=^$ -bench=BenchmarkSparseMerkleTrie ./benchmarks -timeout 0
+	go test -tags=benchmark -benchmem -run=^$$ -bench=BenchmarkSparseMerkleTrie ./benchmarks -timeout 0
 
 .PHONY: benchmark_smt_fill
 benchmark_smt_fill:  ## runs a benchmark on filling the SMT with different amounts of values
-	go test -tags=benchmark -benchmem -run=^$ -bench=BenchmarkSparseMerkleTrie_Fill ./benchmarks -timeout 0 -benchtime 10x
+	go test -tags=benchmark -benchmem -run=^$$ -bench=BenchmarkSparseMerkleTrie_Fill ./benchmarks -timeout 0 -benchtime 10x
 
 .PHONY: benchmark_smt_ops
 benchmark_smt_ops:  ## runs the benchmarks testing different operations on the SMT against different sized tries
-	go test -tags=benchmark -benchmem -run=^$ -bench='BenchmarkSparseMerkleTrie_(Update|Get|Prove|Delete)' ./benchmarks -timeout 0
+	go test -tags=benchmark -benchmem -run=^$$ -bench='BenchmarkSparseMerkleTrie_(Update|Get|Prove|Delete)' ./benchmarks -timeout 0
 
 .PHONY: benchmark_smst
 benchmark_smst:  ## runs all benchmarks for the SMST
-	go test -tags=benchmark -benchmem -run=^$ -bench=BenchmarkSparseMerkleSumTrie ./benchmarks -timeout 0
+	go test -tags=benchmark -benchmem -run=^$$ -bench=BenchmarkSparseMerkleSumTrie ./benchmarks -timeout 0
 
 .PHONY: benchmark_smst_fill
 benchmark_smst_fill:  ## runs a benchmark on filling the SMST with different amounts of values
-	go test -tags=benchmark -benchmem -run=^$ -bench=BenchmarkSparseMerkleSumTrie_Fill ./benchmarks -timeout 0 -benchtime 10x
+	go test -tags=benchmark -benchmem -run=^$$ -bench=BenchmarkSparseMerkleSumTrie_Fill ./benchmarks -timeout 0 -benchtime 10x
 
 .PHONY: benchmark_smst_ops
 benchmark_smst_ops:  ## runs the benchmarks test different operations on the SMST against different sized tries
-	go test -tags=benchmark -benchmem -run=^$ -bench='BenchmarkSparseMerkleSumTrie_(Update|Get|Prove|Delete)' ./benchmarks -timeout 0
+	go test -tags=benchmark -benchmem -run=^$$ -bench='BenchmarkSparseMerkleSumTrie_(Update|Get|Prove|Delete)' ./benchmarks -timeout 0
 
 .PHONY: benchmark_proof_sizes
 benchmark_proof_sizes:  ## runs the benchmarks test the proof sizes for different sized tries

--- a/benchmarks/bench_utils_test.go
+++ b/benchmarks/bench_utils_test.go
@@ -38,7 +38,7 @@ var (
 	getSMST = func(s *smt.SMST, i uint64) error {
 		b := make([]byte, 8)
 		binary.LittleEndian.PutUint64(b, i)
-		_, _, err := s.Get(b)
+		_, _, _, err := s.Get(b)
 		return err
 	}
 	proSMST = func(s *smt.SMST, i uint64) error {

--- a/docs/merkle-sum-trie.md
+++ b/docs/merkle-sum-trie.md
@@ -1,5 +1,7 @@
 # Sparse Merkle Sum Trie (smst)
 
+TODO_IN_THIS_PR(@Olshansk): Document the new `count` addition.
+
 <!-- toc -->
 
 - [Sparse Merkle Sum Trie (smst)](#sparse-merkle-sum-trie-smst)

--- a/docs/merkle-sum-trie.md
+++ b/docs/merkle-sum-trie.md
@@ -1,6 +1,6 @@
 # Sparse Merkle Sum Trie (smst)
 
-TODO_IN_THIS_PR(@Olshansk): Document the new `count` addition.
+TODO_IN_THIS_PR(#47): Document the new `count` addition.
 
 <!-- toc -->
 

--- a/docs/merkle-sum-trie.md
+++ b/docs/merkle-sum-trie.md
@@ -1,6 +1,6 @@
 # Sparse Merkle Sum Trie (smst)
 
-TODO_IN_THIS_PR(#47): Document the new `count` addition.
+TODO(#47): Document the new `count` addition.
 
 <!-- toc -->
 

--- a/hasher.go
+++ b/hasher.go
@@ -124,7 +124,7 @@ func (th *trieHasher) digestInnerNode(leftData, rightData []byte) (digest, value
 // digestSumNode returns the encoded leaf node data as well as its hash (i.e. digest)
 func (th *trieHasher) digestSumLeafNode(path, data []byte) (digest, value []byte) {
 	value = encodeLeafNode(path, data)
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(value)
 
 	digest = th.digestData(value)
 	digest = append(digest, value[firstSumByteIdx:firstCountByteIdx]...)
@@ -136,7 +136,7 @@ func (th *trieHasher) digestSumLeafNode(path, data []byte) (digest, value []byte
 // digestSumInnerNode returns the encoded inner node data as well as its hash (i.e. digest)
 func (th *trieHasher) digestSumInnerNode(leftData, rightData []byte) (digest, value []byte) {
 	value = encodeSumInnerNode(leftData, rightData)
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(value)
 
 	digest = th.digestData(value)
 	digest = append(digest, value[firstSumByteIdx:firstCountByteIdx]...)
@@ -155,7 +155,7 @@ func (th *trieHasher) parseInnerNode(data []byte) (leftData, rightData []byte) {
 // parseSumInnerNode returns the encoded left & right nodes, as well as the sum
 // and non-empty leaf count in the sub-trie of the current node.
 func (th *trieHasher) parseSumInnerNode(data []byte) (leftData, rightData []byte, sum, count uint64) {
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 
 	// Extract the sum from the encoded node data
 	var sumBz [sumSizeBytes]byte

--- a/hasher.go
+++ b/hasher.go
@@ -124,10 +124,11 @@ func (th *trieHasher) digestInnerNode(leftData, rightData []byte) (digest, value
 // digestSumNode returns the encoded leaf node data as well as its hash (i.e. digest)
 func (th *trieHasher) digestSumLeafNode(path, data []byte) (digest, value []byte) {
 	value = encodeLeafNode(path, data)
-	digest = th.digestData(value)
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
 
-	firstSumByteIdx, _ := GetFirstMetaByteIdx(value)
-	digest = append(digest, value[:firstSumByteIdx]...)
+	digest = th.digestData(value)
+	digest = append(digest, value[firstSumByteIdx:firstCountByteIdx]...)
+	digest = append(digest, value[firstCountByteIdx:]...)
 
 	return
 }
@@ -135,7 +136,6 @@ func (th *trieHasher) digestSumLeafNode(path, data []byte) (digest, value []byte
 // digestSumInnerNode returns the encoded inner node data as well as its hash (i.e. digest)
 func (th *trieHasher) digestSumInnerNode(leftData, rightData []byte) (digest, value []byte) {
 	value = encodeSumInnerNode(leftData, rightData)
-
 	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
 
 	digest = th.digestData(value)

--- a/hasher.go
+++ b/hasher.go
@@ -153,7 +153,7 @@ func (th *trieHasher) parseInnerNode(data []byte) (leftData, rightData []byte) {
 }
 
 // parseSumInnerNode returns the encoded left & right nodes, as well as the sum
-// and non-empty leafs in the sub-trie of the current node.
+// and non-empty leaf count in the sub-trie of the current node.
 func (th *trieHasher) parseSumInnerNode(data []byte) (leftData, rightData []byte, sum, count uint64) {
 	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
 

--- a/node_encoders.go
+++ b/node_encoders.go
@@ -80,29 +80,40 @@ func encodeExtensionNode(pathBounds [2]byte, path, childData []byte) (data []byt
 
 // encodeSumInnerNode encodes an inner node for an smst given the data for both children
 func encodeSumInnerNode(leftData, rightData []byte) (data []byte) {
-	// Compute the sum of the current node
-	var sum [sumSizeBytes]byte
-	leftSum := parseSum(leftData)
-	rightSum := parseSum(rightData)
-	// TODO_CONSIDERATION: ` I chose BigEndian for readability but most computers
-	// now are optimized for LittleEndian encoding could be a micro optimization one day.`
-	binary.BigEndian.PutUint64(sum[:], leftSum+rightSum)
+	leftSum, leftCount := parseSumAndCount(leftData)
+	rightSum, rightCount := parseSumAndCount(rightData)
+
+	// Compute the SumBz of the current node
+	var SumBz [sumSizeBytes]byte
+	binary.BigEndian.PutUint64(SumBz[:], leftSum+rightSum)
+
+	// Compute the count of the current node
+	var countBz [countSizeBytes]byte
+	binary.BigEndian.PutUint64(countBz[:], leftCount+rightCount)
 
 	// Prepare and return the encoded inner node data
 	data = encodeInnerNode(leftData, rightData)
-	data = append(data, sum[:]...)
+	data = append(data, SumBz[:]...)
+	data = append(data, countBz[:]...)
 	return
 }
 
 // encodeSumExtensionNode encodes the data of a sum extension nodes
 func encodeSumExtensionNode(pathBounds [2]byte, path, childData []byte) (data []byte) {
-	// Compute the sum of the current node
-	var sum [sumSizeBytes]byte
-	copy(sum[:], childData[len(childData)-sumSizeBytes:])
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(childData)
+
+	// Compute the sumBz of the current node
+	var sumBz [sumSizeBytes]byte
+	copy(sumBz[:], childData[firstSumByteIdx:firstCountByteIdx])
+
+	// Compute the count of the current node
+	var countBz [countSizeBytes]byte
+	copy(countBz[:], childData[firstCountByteIdx:])
 
 	// Prepare and return the encoded inner node data
 	data = encodeExtensionNode(pathBounds, path, childData)
-	data = append(data, sum[:]...)
+	data = append(data, sumBz[:]...)
+	data = append(data, countBz[:]...)
 	return
 }
 
@@ -114,11 +125,20 @@ func checkPrefix(data, prefix []byte) {
 }
 
 // parseSum parses the sum from the encoded node data
-func parseSum(data []byte) uint64 {
-	sum := uint64(0)
-	sumBz := data[len(data)-sumSizeBytes:]
+func parseSumAndCount(data []byte) (sum, count uint64) {
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+
+	sumBz := data[firstSumByteIdx:firstCountByteIdx]
 	if !bytes.Equal(sumBz, defaultEmptySum[:]) {
+		// TODO_CONSIDERATION: We chose BigEndian for readability but most computers
+		// now are optimized for LittleEndian encoding could be a micro optimization one day.`
 		sum = binary.BigEndian.Uint64(sumBz)
 	}
-	return sum
+
+	countBz := data[firstCountByteIdx:]
+	if !bytes.Equal(countBz, defaultEmptyCount[:]) {
+		count = binary.BigEndian.Uint64(countBz)
+	}
+
+	return
 }

--- a/node_encoders.go
+++ b/node_encoders.go
@@ -100,7 +100,7 @@ func encodeSumInnerNode(leftData, rightData []byte) (data []byte) {
 
 // encodeSumExtensionNode encodes the data of a sum extension node
 func encodeSumExtensionNode(pathBounds [2]byte, path, childData []byte) (data []byte) {
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(childData)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(childData)
 
 	// Compute the sumBz of the current node
 	var sumBz [sumSizeBytes]byte
@@ -126,7 +126,7 @@ func checkPrefix(data, prefix []byte) {
 
 // parseSum parses the sum from the encoded node data
 func parseSumAndCount(data []byte) (sum, count uint64) {
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 
 	sumBz := data[firstSumByteIdx:firstCountByteIdx]
 	if !bytes.Equal(sumBz, defaultEmptySum[:]) {

--- a/node_encoders.go
+++ b/node_encoders.go
@@ -98,7 +98,7 @@ func encodeSumInnerNode(leftData, rightData []byte) (data []byte) {
 	return
 }
 
-// encodeSumExtensionNode encodes the data of a sum extension nodes
+// encodeSumExtensionNode encodes the data of a sum extension node
 func encodeSumExtensionNode(pathBounds [2]byte, path, childData []byte) (data []byte) {
 	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(childData)
 

--- a/proofs.go
+++ b/proofs.go
@@ -202,14 +202,15 @@ func (proof *SparseMerkleClosestProof) Unmarshal(bz []byte) error {
 
 // GetValueHash returns the value hash of the closest proof.
 func (proof *SparseMerkleClosestProof) GetValueHash(spec *TrieSpec) []byte {
-	if proof.ClosestValueHash == nil {
+	data := proof.ClosestValueHash
+	if data == nil {
 		return nil
 	}
 	if spec.sumTrie {
-		firstSumByteIdx, _ := GetFirstMetaByteIdx(proof.ClosestValueHash)
-		return proof.ClosestValueHash[:firstSumByteIdx]
+		firstSumByteIdx, _ := GetFirstMetaByteIdx(data)
+		return data[:firstSumByteIdx]
 	}
-	return proof.ClosestValueHash
+	return data
 }
 
 func (proof *SparseMerkleClosestProof) validateBasic(spec *TrieSpec) error {

--- a/proofs.go
+++ b/proofs.go
@@ -207,7 +207,7 @@ func (proof *SparseMerkleClosestProof) GetValueHash(spec *TrieSpec) []byte {
 		return nil
 	}
 	if spec.sumTrie {
-		firstSumByteIdx, _ := GetFirstMetaByteIdx(data)
+		firstSumByteIdx, _ := getFirstMetaByteIdx(data)
 		return data[:firstSumByteIdx]
 	}
 	return data
@@ -379,7 +379,7 @@ func VerifyClosestProof(proof *SparseMerkleClosestProof, root []byte, spec *Trie
 	}
 
 	data := proof.ClosestValueHash
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 
 	sumBz := data[firstSumByteIdx:firstCountByteIdx]
 	sum := binary.BigEndian.Uint64(sumBz)

--- a/proofs.go
+++ b/proofs.go
@@ -373,7 +373,7 @@ func VerifyClosestProof(proof *SparseMerkleClosestProof, root []byte, spec *Trie
 		return VerifyProof(proof.ClosestProof, root, proof.ClosestPath, proof.ClosestValueHash, nilSpec)
 	}
 
-	// TODO_IN_THIS_PR: What is this case?
+	// TODO_DOCUMENT: Understand and explain (in comments) why this case is needed
 	if proof.ClosestValueHash == nil {
 		return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, nil, 0, 0, nilSpec)
 	}

--- a/proofs.go
+++ b/proofs.go
@@ -206,7 +206,8 @@ func (proof *SparseMerkleClosestProof) GetValueHash(spec *TrieSpec) []byte {
 		return nil
 	}
 	if spec.sumTrie {
-		return proof.ClosestValueHash[:len(proof.ClosestValueHash)-sumSizeBytes]
+		firstSumByteIdx, _ := GetFirstMetaByteIdx(proof.ClosestValueHash)
+		return proof.ClosestValueHash[:firstSumByteIdx]
 	}
 	return proof.ClosestValueHash
 }
@@ -323,22 +324,30 @@ func VerifyProof(proof *SparseMerkleProof, root, key, value []byte, spec *TrieSp
 }
 
 // VerifySumProof verifies a Merkle proof for a sum trie.
-func VerifySumProof(proof *SparseMerkleProof, root, key, value []byte, sum uint64, spec *TrieSpec) (bool, error) {
+func VerifySumProof(proof *SparseMerkleProof, root, key, value []byte, sum, count uint64, spec *TrieSpec) (bool, error) {
 	var sumBz [sumSizeBytes]byte
 	binary.BigEndian.PutUint64(sumBz[:], sum)
+
+	var countBz [countSizeBytes]byte
+	binary.BigEndian.PutUint64(countBz[:], count)
+
 	valueHash := spec.valueHash(value)
 	valueHash = append(valueHash, sumBz[:]...)
+	valueHash = append(valueHash, countBz[:]...)
 	if bytes.Equal(value, defaultEmptyValue) && sum == 0 {
 		valueHash = defaultEmptyValue
 	}
+
 	smtSpec := &TrieSpec{
 		th:      spec.th,
 		ph:      spec.ph,
 		vh:      spec.vh,
 		sumTrie: spec.sumTrie,
 	}
+
 	nvh := WithValueHasher(nil)
 	nvh(smtSpec)
+
 	return VerifyProof(proof, root, key, valueHash, smtSpec)
 }
 
@@ -348,26 +357,37 @@ func VerifyClosestProof(proof *SparseMerkleClosestProof, root []byte, spec *Trie
 	if err := proof.validateBasic(spec); err != nil {
 		return false, errors.Join(ErrBadProof, err)
 	}
+
 	// Create a new TrieSpec with a nil path hasher.
-	// Since the ClosestProof already contains a hashed path, double hashing it
-	// will invalidate the proof.
+	// Since the ClosestProof already contains a hashed path, double hashing it will invalidate the proof.
 	nilSpec := &TrieSpec{
 		th:      spec.th,
 		ph:      newNilPathHasher(spec.ph.PathSize()),
 		vh:      spec.vh,
 		sumTrie: spec.sumTrie,
 	}
+
+	// Verify the closest proof for a basic SMT
 	if !nilSpec.sumTrie {
 		return VerifyProof(proof.ClosestProof, root, proof.ClosestPath, proof.ClosestValueHash, nilSpec)
 	}
+
+	// TODO_IN_THIS_PR: What is this case?
 	if proof.ClosestValueHash == nil {
-		return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, nil, 0, nilSpec)
+		return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, nil, 0, 0, nilSpec)
 	}
-	sumBz := proof.ClosestValueHash[len(proof.ClosestValueHash)-sumSizeBytes:]
+
+	data := proof.ClosestValueHash
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+
+	sumBz := data[firstSumByteIdx:firstCountByteIdx]
 	sum := binary.BigEndian.Uint64(sumBz)
 
-	valueHash := proof.ClosestValueHash[:len(proof.ClosestValueHash)-sumSizeBytes]
-	return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, valueHash, sum, nilSpec)
+	countBz := data[firstCountByteIdx:]
+	count := binary.BigEndian.Uint64(countBz)
+
+	valueHash := data[:firstSumByteIdx]
+	return VerifySumProof(proof.ClosestProof, root, proof.ClosestPath, valueHash, sum, count, nilSpec)
 }
 
 // verifyProofWithUpdates
@@ -445,14 +465,14 @@ func VerifyCompactSumProof(
 	proof *SparseCompactMerkleProof,
 	root []byte,
 	key, value []byte,
-	sum uint64,
+	sum, count uint64,
 	spec *TrieSpec,
 ) (bool, error) {
 	decompactedProof, err := DecompactProof(proof, spec)
 	if err != nil {
 		return false, errors.Join(ErrBadProof, err)
 	}
-	return VerifySumProof(decompactedProof, root, key, value, sum, spec)
+	return VerifySumProof(decompactedProof, root, key, value, sum, count, spec)
 }
 
 // VerifyCompactClosestProof is similar to VerifyClosestProof but for a compacted merkle proof

--- a/proofs_test.go
+++ b/proofs_test.go
@@ -178,7 +178,7 @@ func randomizeSumProof(proof *SparseMerkleProof) *SparseMerkleProof {
 	sideNodes := make([][]byte, len(proof.SideNodes))
 	for i := range sideNodes {
 		data := proof.SideNodes[i]
-		firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+		firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 		sideNodes[i] = make([]byte, len(data)-sumSizeBytes-countSizeBytes)
 		rand.Read(sideNodes[i]) // nolint: errcheck
 		sideNodes[i] = append(sideNodes[i], data[firstSumByteIdx:firstCountByteIdx]...)

--- a/proofs_test.go
+++ b/proofs_test.go
@@ -177,9 +177,12 @@ func randomizeProof(proof *SparseMerkleProof) *SparseMerkleProof {
 func randomizeSumProof(proof *SparseMerkleProof) *SparseMerkleProof {
 	sideNodes := make([][]byte, len(proof.SideNodes))
 	for i := range sideNodes {
-		sideNodes[i] = make([]byte, len(proof.SideNodes[i])-sumSizeBytes)
+		data := proof.SideNodes[i]
+		firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+		sideNodes[i] = make([]byte, len(data)-sumSizeBytes-countSizeBytes)
 		rand.Read(sideNodes[i]) // nolint: errcheck
-		sideNodes[i] = append(sideNodes[i], proof.SideNodes[i][len(proof.SideNodes[i])-sumSizeBytes:]...)
+		sideNodes[i] = append(sideNodes[i], data[firstSumByteIdx:firstCountByteIdx]...)
+		sideNodes[i] = append(sideNodes[i], data[firstCountByteIdx:]...)
 	}
 	return &SparseMerkleProof{
 		SideNodes:             sideNodes,

--- a/root_test.go
+++ b/root_test.go
@@ -60,6 +60,7 @@ func TestMerkleRoot_TrieTypes(t *testing.T) {
 				}
 				require.NotNil(t, trie.Sum())
 				require.EqualValues(t, 45, trie.Sum())
+				require.EqualValues(t, 10, trie.Count())
 
 				return
 			}

--- a/smst.go
+++ b/smst.go
@@ -77,18 +77,17 @@ func (smst *SMST) Spec() *TrieSpec {
 	return &smst.TrieSpec
 }
 
-// Get retrieves the value digest for the given key, along with its weight and count
-// of non-empty leafs assuming the node exists.
-func (smst *SMST) Get(key []byte) (valueDigest []byte, weight, count uint64, err error) {
+// Get retrieves the value digest for the given key, along with its weight assuming the node exists.
+func (smst *SMST) Get(key []byte) (valueDigest []byte, weight uint64, err error) {
 	// Retrieve the value digest from the trie for the given key
 	value, err := smst.SMT.Get(key)
 	if err != nil {
-		return nil, 0, 0, err
+		return nil, 0, err
 	}
 
 	// Check if it has an empty branch
 	if bytes.Equal(value, defaultEmptyValue) {
-		return defaultEmptyValue, 0, 0, nil
+		return defaultEmptyValue, 0, nil
 	}
 
 	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
@@ -104,7 +103,7 @@ func (smst *SMST) Get(key []byte) (valueDigest []byte, weight, count uint64, err
 	// Retrieve the number of non-empty nodes in the sub trie
 	var countBz [countSizeBytes]byte
 	copy(countBz[:], value[firstCountByteIdx:])
-	count = binary.BigEndian.Uint64(countBz[:])
+	count := binary.BigEndian.Uint64(countBz[:])
 
 	// TODO_IN_THIS_PR: Consider not retuning count here because it should always be 1
 	if count != 1 {
@@ -112,7 +111,7 @@ func (smst *SMST) Get(key []byte) (valueDigest []byte, weight, count uint64, err
 	}
 
 	// Return the value digest and weight
-	return valueDigest, weight, count, nil
+	return valueDigest, weight, nil
 }
 
 // Update inserts the value and weight into the trie for the given key.

--- a/smst.go
+++ b/smst.go
@@ -111,7 +111,6 @@ func (smst *SMST) Get(key []byte) (valueDigest []byte, weight uint64, err error)
 	copy(countBz[:], value[firstCountByteIdx:])
 	count := binary.BigEndian.Uint64(countBz[:])
 
-	// TODO_IN_THIS_PR: Consider not retuning count here because it should always be 1
 	if count != 1 {
 		panic("count for leaf node should always be 1")
 	}

--- a/smst.go
+++ b/smst.go
@@ -86,7 +86,7 @@ func (smst *SMST) Get(key []byte) (valueDigest []byte, weight, count uint64, err
 		return nil, 0, 0, err
 	}
 
-	// Check if it ias an empty branch
+	// Check if it has an empty branch
 	if bytes.Equal(value, defaultEmptyValue) {
 		return defaultEmptyValue, 0, 0, nil
 	}

--- a/smst.go
+++ b/smst.go
@@ -16,7 +16,7 @@ const (
 	//
 	// TODO_TECHDEBT: Since we are using sha256, we could theoretically have
 	// 2^256 leaves. This would require 32 bytes, and would not fit in a uint64.
-	// For now, we are assuming that we will not have more than 2^64 leaves.
+	// For now, we are assuming that we will not have more than 2^64 - 1 leaves.
 	//
 	// This need for this variable could be removed, but is kept around to enable
 	// a simpler transition to little endian encoding if/when necessary.

--- a/smst.go
+++ b/smst.go
@@ -77,7 +77,8 @@ func (smst *SMST) Spec() *TrieSpec {
 	return &smst.TrieSpec
 }
 
-// Get retrieves the value digest for the given key, along with its weight assuming the node exists.
+// Get retrieves the value digest for the given key, along with its weight assuming
+// the node exists, otherwise the default placeholder values are returned 
 func (smst *SMST) Get(key []byte) (valueDigest []byte, weight uint64, err error) {
 	// Retrieve the value digest from the trie for the given key
 	value, err := smst.SMT.Get(key)

--- a/smst.go
+++ b/smst.go
@@ -91,7 +91,7 @@ func (smst *SMST) Get(key []byte) (valueDigest []byte, weight uint64, err error)
 		return defaultEmptyValue, 0, nil
 	}
 
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(value)
 
 	// Extract the value digest only
 	valueDigest = value[:firstSumByteIdx]
@@ -179,7 +179,7 @@ func (smst *SMST) Sum() uint64 {
 		panic("SMST: not a merkle sum trie")
 	}
 
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(rootDigest)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(rootDigest)
 
 	var sumBz [sumSizeBytes]byte
 	copy(sumBz[:], rootDigest[firstSumByteIdx:firstCountByteIdx])
@@ -194,17 +194,17 @@ func (smst *SMST) Count() uint64 {
 		panic("SMST: not a merkle sum trie")
 	}
 
-	_, firstCountByteIdx := GetFirstMetaByteIdx(rootDigest)
+	_, firstCountByteIdx := getFirstMetaByteIdx(rootDigest)
 
 	var countBz [countSizeBytes]byte
 	copy(countBz[:], rootDigest[firstCountByteIdx:])
 	return binary.BigEndian.Uint64(countBz[:])
 }
 
-// GetFirstByte returns the index of the first count byte and the first sum byte
+// getFirstMetaByteIdx returns the index of the first count byte and the first sum byte
 // in the data slice provided. This is useful metadata when parsing the data
 // of any node in the trie.
-func GetFirstMetaByteIdx(data []byte) (firstSumByteIdx, firstCountByteIdx int) {
+func getFirstMetaByteIdx(data []byte) (firstSumByteIdx, firstCountByteIdx int) {
 	firstCountByteIdx = len(data) - countSizeBytes
 	firstSumByteIdx = firstCountByteIdx - sumSizeBytes
 	return

--- a/smst.go
+++ b/smst.go
@@ -86,7 +86,7 @@ func (smst *SMST) Get(key []byte) (valueDigest []byte, weight uint64, err error)
 		return nil, 0, err
 	}
 
-	// Check if it has an empty branch
+	// Check if it is an empty branch
 	if bytes.Equal(value, defaultEmptyValue) {
 		return defaultEmptyValue, 0, nil
 	}

--- a/smst.go
+++ b/smst.go
@@ -13,9 +13,14 @@ const (
 	sumSizeBytes = 8
 
 	// The number of bytes used to track the count of non-empty nodes in the trie.
+	//
 	// TODO_TECHDEBT: Since we are using sha256, we could theoretically have
 	// 2^256 leaves. This would require 32 bytes, and would not fit in a uint64.
 	// For now, we are assuming that we will not have more than 2^64 leaves.
+	//
+	// This need for this variable could be removed, but is kept around to enable
+	// a simpler transition to little endian encoding if/when necessary.
+	// Ref: https://github.com/pokt-network/smt/pull/46#discussion_r1636975124
 	countSizeBytes = 8
 )
 
@@ -78,7 +83,7 @@ func (smst *SMST) Spec() *TrieSpec {
 }
 
 // Get retrieves the value digest for the given key, along with its weight assuming
-// the node exists, otherwise the default placeholder values are returned 
+// the node exists, otherwise the default placeholder values are returned
 func (smst *SMST) Get(key []byte) (valueDigest []byte, weight uint64, err error) {
 	// Retrieve the value digest from the trie for the given key
 	value, err := smst.SMT.Get(key)

--- a/smst_example_test.go
+++ b/smst_example_test.go
@@ -36,13 +36,13 @@ func ExampleSMST() {
 	root := trie.Root()
 
 	// Verify the Merkle proof for "foo"="oof" where "foo" has a sum of 10
-	valid_true1, _ := smt.VerifySumProof(proof1, root, []byte("foo"), []byte("oof"), 10, trie.Spec())
+	valid_true1, _ := smt.VerifySumProof(proof1, root, []byte("foo"), []byte("oof"), 10, 1, trie.Spec())
 	// Verify the Merkle proof for "baz"="zab" where "baz" has a sum of 7
-	valid_true2, _ := smt.VerifySumProof(proof2, root, []byte("baz"), []byte("zab"), 7, trie.Spec())
+	valid_true2, _ := smt.VerifySumProof(proof2, root, []byte("baz"), []byte("zab"), 7, 1, trie.Spec())
 	// Verify the Merkle proof for "bin"="nib" where "bin" has a sum of 3
-	valid_true3, _ := smt.VerifySumProof(proof3, root, []byte("bin"), []byte("nib"), 3, trie.Spec())
+	valid_true3, _ := smt.VerifySumProof(proof3, root, []byte("bin"), []byte("nib"), 3, 1, trie.Spec())
 	// Fail to verify the Merkle proof for "foo"="oof" where "foo" has a sum of 11
-	valid_false1, _ := smt.VerifySumProof(proof1, root, []byte("foo"), []byte("oof"), 11, trie.Spec())
+	valid_false1, _ := smt.VerifySumProof(proof1, root, []byte("foo"), []byte("oof"), 11, 1, trie.Spec())
 	fmt.Println(valid_true1, valid_true2, valid_true3, valid_false1)
 	// Output: true true true false
 }

--- a/smst_example_test.go
+++ b/smst_example_test.go
@@ -2,13 +2,16 @@ package smt_test
 
 import (
 	"crypto/sha256"
-	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/pokt-network/smt"
 	"github.com/pokt-network/smt/kvstore/simplemap"
 )
 
-func ExampleSMST() {
+// TestExampleSMT is a test that aims to act as an example of how to use the SMST.
+func TestExampleSMST(t *testing.T) {
 	// Initialise a new in-memory key-value store to store the nodes of the trie
 	// (Note: the trie only stores hashed values, not raw value data)
 	nodeStore := simplemap.NewSimpleMap()
@@ -37,12 +40,20 @@ func ExampleSMST() {
 
 	// Verify the Merkle proof for "foo"="oof" where "foo" has a sum of 10
 	valid_true1, _ := smt.VerifySumProof(proof1, root, []byte("foo"), []byte("oof"), 10, 1, trie.Spec())
+	require.True(t, valid_true1)
 	// Verify the Merkle proof for "baz"="zab" where "baz" has a sum of 7
 	valid_true2, _ := smt.VerifySumProof(proof2, root, []byte("baz"), []byte("zab"), 7, 1, trie.Spec())
+	require.True(t, valid_true2)
 	// Verify the Merkle proof for "bin"="nib" where "bin" has a sum of 3
 	valid_true3, _ := smt.VerifySumProof(proof3, root, []byte("bin"), []byte("nib"), 3, 1, trie.Spec())
+	require.True(t, valid_true3)
 	// Fail to verify the Merkle proof for "foo"="oof" where "foo" has a sum of 11
 	valid_false1, _ := smt.VerifySumProof(proof1, root, []byte("foo"), []byte("oof"), 11, 1, trie.Spec())
-	fmt.Println(valid_true1, valid_true2, valid_true3, valid_false1)
-	// Output: true true true false
+	require.False(t, valid_false1)
+
+	// Verify the total sum of the trie
+	require.EqualValues(t, 20, trie.Sum())
+
+	// Verify the number of non-empty leafs in the trie
+	require.EqualValues(t, 3, trie.Count())
 }

--- a/smst_proofs_test.go
+++ b/smst_proofs_test.go
@@ -33,10 +33,10 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	proof, err = smst.Prove([]byte("testKey3"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
-	result, err = VerifySumProof(proof, base.placeholder(), []byte("testKey3"), defaultEmptyValue, 0, base)
+	result, err = VerifySumProof(proof, base.placeholder(), []byte("testKey3"), defaultEmptyValue, 0, 0, base)
 	require.NoError(t, err)
 	require.True(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey3"), []byte("badValue"), 5, base)
+	result, err = VerifySumProof(proof, root, []byte("testKey3"), []byte("badValue"), 5, 1, base)
 	require.NoError(t, err)
 	require.False(t, result)
 
@@ -47,16 +47,16 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	proof, err = smst.Prove([]byte("testKey"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, base) // valid
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, 1, base) // valid
 	require.NoError(t, err)
 	require.True(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 5, base) // wrong value
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 5, 1, base) // wrong value
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 10, base) // wrong sum
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 10, 1, base) // wrong sum
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 10, base) // wrong value and sum
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 10, 1, base) // wrong value and sum
 	require.NoError(t, err)
 	require.False(t, result)
 
@@ -67,16 +67,16 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	proof, err = smst.Prove([]byte("testKey"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, base) // valid
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, 1, base) // valid
 	require.NoError(t, err)
 	require.True(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 5, base) // wrong value
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 5, 1, base) // wrong value
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 10, base) // wrong sum
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 10, 1, base) // wrong sum
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 10, base) // wrong value and sum
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 10, 1, base) // wrong value and sum
 	require.NoError(t, err)
 	require.False(t, result)
 	result, err = VerifySumProof(
@@ -85,6 +85,7 @@ func TestSMST_Proof_Operations(t *testing.T) {
 		[]byte("testKey"),
 		[]byte("testValue"),
 		5,
+		1,
 		base,
 	) // invalid proof
 	require.NoError(t, err)
@@ -93,16 +94,16 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	proof, err = smst.Prove([]byte("testKey2"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
-	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("testValue"), 5, base) // valid
+	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("testValue"), 5, 1, base) // valid
 	require.NoError(t, err)
 	require.True(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("badValue"), 5, base) // wrong value
+	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("badValue"), 5, 1, base) // wrong value
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("testValue"), 10, base) // wrong sum
+	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("testValue"), 10, 1, base) // wrong sum
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("badValue"), 10, base) // wrong value and sum
+	result, err = VerifySumProof(proof, root, []byte("testKey2"), []byte("badValue"), 10, 1, base) // wrong value and sum
 	require.NoError(t, err)
 	require.False(t, result)
 	result, err = VerifySumProof(
@@ -111,22 +112,23 @@ func TestSMST_Proof_Operations(t *testing.T) {
 		[]byte("testKey2"),
 		[]byte("testValue"),
 		5,
+		1,
 		base,
 	) // invalid proof
 	require.NoError(t, err)
 	require.False(t, result)
 
-	// Try proving a default value for a non-default leaf.
+	// Try (and fail) proving a default value for a non-default leaf.
 	var sum [sumSizeBytes]byte
 	binary.BigEndian.PutUint64(sum[:], 5)
-	tval := base.valueHash([]byte("testValue"))
-	tval = append(tval, sum[:]...)
-	_, leafData := base.th.digestSumLeafNode(base.ph.Path([]byte("testKey2")), tval)
+	testVal := base.valueHash([]byte("testValue"))
+	testVal = append(testVal, sum[:]...)
+	_, leafData := base.th.digestSumLeafNode(base.ph.Path([]byte("testKey2")), testVal)
 	proof = &SparseMerkleProof{
 		SideNodes:             proof.SideNodes,
 		NonMembershipLeafData: leafData,
 	}
-	result, err = VerifySumProof(proof, root, []byte("testKey2"), defaultEmptyValue, 0, base)
+	result, err = VerifySumProof(proof, root, []byte("testKey2"), defaultEmptyValue, 0, 0, base)
 	require.ErrorIs(t, err, ErrBadProof)
 	require.False(t, result)
 
@@ -134,13 +136,13 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	proof, err = smst.Prove([]byte("testKey3"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
-	result, err = VerifySumProof(proof, root, []byte("testKey3"), defaultEmptyValue, 0, base) // valid
+	result, err = VerifySumProof(proof, root, []byte("testKey3"), defaultEmptyValue, 0, 0, base) // valid
 	require.NoError(t, err)
 	require.True(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey3"), []byte("badValue"), 0, base) // wrong value
+	result, err = VerifySumProof(proof, root, []byte("testKey3"), []byte("badValue"), 0, 0, base) // wrong value
 	require.NoError(t, err)
 	require.False(t, result)
-	result, err = VerifySumProof(proof, root, []byte("testKey3"), defaultEmptyValue, 5, base) // wrong sum
+	result, err = VerifySumProof(proof, root, []byte("testKey3"), defaultEmptyValue, 5, 0, base) // wrong sum
 	require.NoError(t, err)
 	require.False(t, result)
 	result, err = VerifySumProof(
@@ -148,6 +150,7 @@ func TestSMST_Proof_Operations(t *testing.T) {
 		root,
 		[]byte("testKey3"),
 		defaultEmptyValue,
+		0,
 		0,
 		base,
 	) // invalid proof
@@ -180,7 +183,7 @@ func TestSMST_Proof_ValidateBasic(t *testing.T) {
 	}
 	proof.SideNodes = sideNodes
 	require.EqualError(t, proof.validateBasic(base), "too many side nodes: got 257 but max is 256")
-	result, err := VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, base)
+	result, err := VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, 1, base)
 	require.ErrorIs(t, err, ErrBadProof)
 	require.False(t, result)
 	_, err = CompactProof(proof, base)
@@ -190,17 +193,17 @@ func TestSMST_Proof_ValidateBasic(t *testing.T) {
 	proof, _ = smst.Prove([]byte("testKey1"))
 	proof.NonMembershipLeafData = make([]byte, 1)
 	require.EqualError(t, proof.validateBasic(base), "invalid non-membership leaf data size: got 1 but min is 33")
-	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, base)
+	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, 1, base)
 	require.ErrorIs(t, err, ErrBadProof)
 	require.False(t, result)
 	_, err = CompactProof(proof, base)
 	require.Error(t, err)
 
-	// Case: unexpected sidenode size.
+	// Case: unexpected side node size.
 	proof, _ = smst.Prove([]byte("testKey1"))
 	proof.SideNodes[0] = make([]byte, 1)
 	require.EqualError(t, proof.validateBasic(base), "invalid side node size: got 1 but want 40")
-	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, base)
+	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, 1, base)
 	require.ErrorIs(t, err, ErrBadProof)
 	require.False(t, result)
 	_, err = CompactProof(proof, base)
@@ -215,7 +218,7 @@ func TestSMST_Proof_ValidateBasic(t *testing.T) {
 		"invalid sibling data hash: got 437437455c0f5ca33597b9dd2a307bdfcc6833d3c272e101f30ed6358783fc247f0b9966865746c1 but want 1dc9a3da748c53b22c9e54dcafe9e872341babda9b3e50577f0b9966865746c10000000000000009",
 	)
 
-	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, base)
+	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, 1, base)
 	require.ErrorIs(t, err, ErrBadProof)
 	require.False(t, result)
 	_, err = CompactProof(proof, base)
@@ -302,6 +305,7 @@ func TestSMST_ProveClosest(t *testing.T) {
 	var root []byte
 	var err error
 	var sumBz [sumSizeBytes]byte
+	var countBz [countSizeBytes]byte
 
 	smn = simplemap.NewSimpleMap()
 	require.NoError(t, err)
@@ -337,6 +341,8 @@ func TestSMST_ProveClosest(t *testing.T) {
 	closestValueHash := []byte("testValue2")
 	binary.BigEndian.PutUint64(sumBz[:], 24)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
+	binary.BigEndian.PutUint64(countBz[:], 10)
+	closestValueHash = append(closestValueHash, countBz[:]...)
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path[:],
 		FlippedBits:      []int{3, 6},
@@ -427,9 +433,17 @@ func TestSMST_ProveClosest_OneNode(t *testing.T) {
 
 	closestPath := sha256.Sum256([]byte("foo"))
 	closestValueHash := []byte("bar")
+
+	//  Manually insert the sum, which is the weight of the single node in the trie
 	var sumBz [sumSizeBytes]byte
 	binary.BigEndian.PutUint64(sumBz[:], 5)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
+
+	// Manually insert the count, which is 1 for a single leaf
+	var countBz [countSizeBytes]byte
+	binary.BigEndian.PutUint64(countBz[:], 1)
+	closestValueHash = append(closestValueHash, countBz[:]...)
+
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path[:],
 		FlippedBits:      []int{},

--- a/smst_proofs_test.go
+++ b/smst_proofs_test.go
@@ -43,19 +43,28 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	// Add a key, generate and verify a Merkle proof.
 	err = smst.Update([]byte("testKey"), []byte("testValue"), 5)
 	require.NoError(t, err)
+
 	root = smst.Root()
 	proof, err = smst.Prove([]byte("testKey"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, 1, base) // valid
 	require.NoError(t, err)
 	require.True(t, result)
+
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, 2, base) // wrong count
+	require.NoError(t, err)
+	require.False(t, result)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 5, 1, base) // wrong value
 	require.NoError(t, err)
 	require.False(t, result)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 10, 1, base) // wrong sum
 	require.NoError(t, err)
 	require.False(t, result)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 10, 1, base) // wrong value and sum
 	require.NoError(t, err)
 	require.False(t, result)
@@ -63,22 +72,32 @@ func TestSMST_Proof_Operations(t *testing.T) {
 	// Add a key, generate and verify both Merkle proofs.
 	err = smst.Update([]byte("testKey2"), []byte("testValue"), 5)
 	require.NoError(t, err)
+
 	root = smst.Root()
 	proof, err = smst.Prove([]byte("testKey"))
 	require.NoError(t, err)
 	checkCompactEquivalence(t, proof, base)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, 1, base) // valid
 	require.NoError(t, err)
 	require.True(t, result)
+
+	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 5, 2, base) // wrong count
+	require.NoError(t, err)
+	require.False(t, result)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 5, 1, base) // wrong value
 	require.NoError(t, err)
 	require.False(t, result)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("testValue"), 10, 1, base) // wrong sum
 	require.NoError(t, err)
 	require.False(t, result)
+
 	result, err = VerifySumProof(proof, root, []byte("testKey"), []byte("badValue"), 10, 1, base) // wrong value and sum
 	require.NoError(t, err)
 	require.False(t, result)
+
 	result, err = VerifySumProof(
 		randomizeSumProof(proof),
 		root,

--- a/smst_proofs_test.go
+++ b/smst_proofs_test.go
@@ -202,7 +202,7 @@ func TestSMST_Proof_ValidateBasic(t *testing.T) {
 	// Case: unexpected side node size.
 	proof, _ = smst.Prove([]byte("testKey1"))
 	proof.SideNodes[0] = make([]byte, 1)
-	require.EqualError(t, proof.validateBasic(base), "invalid side node size: got 1 but want 40")
+	require.EqualError(t, proof.validateBasic(base), "invalid side node size: got 1 but want 48")
 	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, 1, base)
 	require.ErrorIs(t, err, ErrBadProof)
 	require.False(t, result)
@@ -215,7 +215,7 @@ func TestSMST_Proof_ValidateBasic(t *testing.T) {
 	require.EqualError(
 		t,
 		proof.validateBasic(base),
-		"invalid sibling data hash: got 437437455c0f5ca33597b9dd2a307bdfcc6833d3c272e101f30ed6358783fc247f0b9966865746c1 but want 1dc9a3da748c53b22c9e54dcafe9e872341babda9b3e50577f0b9966865746c10000000000000009",
+		"invalid sibling data hash: got 30ecfc36781633f6765088e69165733d7192483b4468ca53ef21794bb035f72f799a6026c448b3eacafa2b82ca1ff7f2 but want 3c54b08cc0074a44a12cb0ea0486d29d799a6026c448b3eacafa2b82ca1ff7f200000000000000090000000000000003",
 	)
 
 	result, err = VerifySumProof(proof, root, []byte("testKey1"), []byte("testValue1"), 1, 1, base)
@@ -341,7 +341,7 @@ func TestSMST_ProveClosest(t *testing.T) {
 	closestValueHash := []byte("testValue2")
 	binary.BigEndian.PutUint64(sumBz[:], 24)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
-	binary.BigEndian.PutUint64(countBz[:], 10)
+	binary.BigEndian.PutUint64(countBz[:], 1)
 	closestValueHash = append(closestValueHash, countBz[:]...)
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path[:],
@@ -369,6 +369,7 @@ func TestSMST_ProveClosest(t *testing.T) {
 	closestValueHash = []byte("testValue4")
 	binary.BigEndian.PutUint64(sumBz[:], 30)
 	closestValueHash = append(closestValueHash, sumBz[:]...)
+	closestValueHash = append(closestValueHash, countBz[:]...)
 	require.Equal(t, proof, &SparseMerkleClosestProof{
 		Path:             path2[:],
 		FlippedBits:      []int{3},

--- a/smst_test.go
+++ b/smst_test.go
@@ -551,43 +551,37 @@ func TestSMST_Retrieval(t *testing.T) {
 	err = smst.Update([]byte("key3"), []byte("value3"), 5)
 	require.NoError(t, err)
 
-	value, sum, count, err := smst.Get([]byte("key1"))
+	value, sum, err := smst.Get([]byte("key1"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value1"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
-	value, sum, count, err = smst.Get([]byte("key2"))
+	value, sum, err = smst.Get([]byte("key2"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value2"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
-	value, sum, count, err = smst.Get([]byte("key3"))
+	value, sum, err = smst.Get([]byte("key3"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value3"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
 	require.NoError(t, smst.Commit())
 
-	value, sum, count, err = smst.Get([]byte("key1"))
+	value, sum, err = smst.Get([]byte("key1"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value1"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
-	value, sum, count, err = smst.Get([]byte("key2"))
+	value, sum, err = smst.Get([]byte("key2"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value2"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
-	value, sum, count, err = smst.Get([]byte("key3"))
+	value, sum, err = smst.Get([]byte("key3"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value3"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
 	root := smst.Root()
 	sum = smst.Sum()
@@ -595,27 +589,24 @@ func TestSMST_Retrieval(t *testing.T) {
 
 	lazy := ImportSparseMerkleSumTrie(snm, sha256.New(), root, WithValueHasher(nil))
 
-	value, sum, count, err = lazy.Get([]byte("key1"))
+	value, sum, err = lazy.Get([]byte("key1"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value1"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
-	value, sum, count, err = lazy.Get([]byte("key2"))
+	value, sum, err = lazy.Get([]byte("key2"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value2"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
-	value, sum, count, err = lazy.Get([]byte("key3"))
+	value, sum, err = lazy.Get([]byte("key3"))
 	require.NoError(t, err)
 	require.Equal(t, []byte("value3"), value)
 	require.Equal(t, uint64(5), sum)
-	require.Equal(t, uint64(1), count)
 
 	sum = lazy.Sum()
 	require.Equal(t, sum, uint64(15))
 
-	count = lazy.Count()
+	count := lazy.Count()
 	require.Equal(t, count, uint64(3))
 }

--- a/smst_test.go
+++ b/smst_test.go
@@ -402,25 +402,25 @@ func TestSMST_OrphanRemoval(t *testing.T) {
 	// sha256(foo)      = 0010... common prefix len 2; 5 nodes (3 inner + 2 leaf)
 	cases := []testCase{
 		{
-			desc:              "single key (testKey2) with a similar prefix to test key (testKey)",
+			desc:              "insert a single key (testKey2) which DOES HAVE a similar prefix to the already present key (testKey)",
 			keys:              []string{"testKey2"},
 			expectedNodeCount: 3,
 			expectedLeafCount: 2,
 		},
 		{
-			desc:              "single key (foo) with a different prefix to test key (testKey)",
+			desc:              "insert a single key (foo) which DOES NOT HAVE a similar prefix to the already present key (testKey)",
 			keys:              []string{"foo"},
 			expectedNodeCount: 4,
 			expectedLeafCount: 2,
 		},
 		{
-			desc:              "override two existing keys",
+			desc:              "override two existing keys which were added by the test cases above",
 			keys:              []string{"testKey2", "foo"},
 			expectedNodeCount: 6,
 			expectedLeafCount: 3,
 		},
 		{
-			desc:              "4",
+			desc:              "add 5 new keys with no common prefix to the existing keys",
 			keys:              []string{"a", "b", "c", "d", "e"},
 			expectedNodeCount: 14,
 			expectedLeafCount: 6,

--- a/smst_test.go
+++ b/smst_test.go
@@ -402,13 +402,13 @@ func TestSMST_OrphanRemoval(t *testing.T) {
 	// sha256(foo)      = 0010... common prefix len 2; 5 nodes (3 inner + 2 leaf)
 	cases := []testCase{
 		{
-			desc:              "insert a single key (testKey2) which DOES HAVE a similar prefix to the already present key (testKey)",
+			desc:              "insert a single key (testKey2) which DOES NOT HAVE a similar prefix to the already present key (testKey)",
 			keys:              []string{"testKey2"},
 			expectedNodeCount: 3,
 			expectedLeafCount: 2,
 		},
 		{
-			desc:              "insert a single key (foo) which DOES NOT HAVE a similar prefix to the already present key (testKey)",
+			desc:              "insert a single key (foo) which DOES HAVE a similar prefix to the already present key (testKey)",
 			keys:              []string{"foo"},
 			expectedNodeCount: 4,
 			expectedLeafCount: 2,

--- a/smst_test.go
+++ b/smst_test.go
@@ -443,16 +443,20 @@ func TestSMST_TotalSum(t *testing.T) {
 	root1 := smst.Root()
 	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(root1)
 
-	// Retrieve and compare the sum
+	// Get the sum from the root hash
 	sumBz := root1[firstSumByteIdx:firstCountByteIdx]
 	rootSum := binary.BigEndian.Uint64(sumBz)
+
+	// Get the count from the root hash
+	countBz := root1[firstCountByteIdx:]
+	rootCount := binary.BigEndian.Uint64(countBz)
+
+	// Retrieve and compare the sum
 	sum := smst.Sum()
 	require.Equal(t, sum, uint64(15))
 	require.Equal(t, sum, rootSum)
 
 	// Retrieve and compare the count
-	countBz := root1[firstCountByteIdx:]
-	rootCount := binary.BigEndian.Uint64(countBz)
 	count := smst.Count()
 	require.Equal(t, count, uint64(3))
 	require.Equal(t, count, rootCount)

--- a/smst_test.go
+++ b/smst_test.go
@@ -475,7 +475,7 @@ func TestSMST_TotalSum(t *testing.T) {
 
 	// Check root hash contains the correct hex sum
 	root1 := smst.Root()
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(root1)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(root1)
 
 	// Get the sum from the root hash
 	sumBz := root1[firstSumByteIdx:firstCountByteIdx]

--- a/smst_test.go
+++ b/smst_test.go
@@ -359,6 +359,7 @@ func TestSMST_OrphanRemoval(t *testing.T) {
 		err = smst.Update([]byte("testKey"), []byte("testValue"), 5)
 		require.NoError(t, err)
 		require.Equal(t, 1, nodeCount(t)) // only root node
+		require.Equal(t, uint64(1), impl.Count())
 	}
 
 	t.Run("delete 1", func(t *testing.T) {
@@ -366,6 +367,7 @@ func TestSMST_OrphanRemoval(t *testing.T) {
 		err = smst.Delete([]byte("testKey"))
 		require.NoError(t, err)
 		require.Equal(t, 0, nodeCount(t))
+		require.Equal(t, uint64(0), impl.Count())
 	})
 
 	t.Run("overwrite 1", func(t *testing.T) {
@@ -373,46 +375,76 @@ func TestSMST_OrphanRemoval(t *testing.T) {
 		err = smst.Update([]byte("testKey"), []byte("testValue2"), 10)
 		require.NoError(t, err)
 		require.Equal(t, 1, nodeCount(t))
+		require.Equal(t, uint64(1), impl.Count())
 	})
-
-	type testCase struct {
-		keys  []string
-		count int
-	}
-	// sha256(testKey)  = 0001...
-	// sha256(testKey2) = 1000... common prefix len 0; 3 nodes (root + 2 leaf)
-	// sha256(foo)      = 0010... common prefix len 2; 5 nodes (3 inner + 2 leaf)
-	cases := []testCase{
-		{[]string{"testKey2"}, 3},
-		{[]string{"foo"}, 4},
-		{[]string{"testKey2", "foo"}, 6},
-		{[]string{"a", "b", "c", "d", "e"}, 14},
-	}
 
 	t.Run("overwrite and delete", func(t *testing.T) {
 		setup()
 		err = smst.Update([]byte("testKey"), []byte("testValue2"), 2)
 		require.NoError(t, err)
 		require.Equal(t, 1, nodeCount(t))
+		require.Equal(t, uint64(1), impl.Count())
 
 		err = smst.Delete([]byte("testKey"))
 		require.NoError(t, err)
 		require.Equal(t, 0, nodeCount(t))
+		require.Equal(t, uint64(0), impl.Count())
+	})
 
-		for tci, tc := range cases {
+	type testCase struct {
+		desc              string
+		keys              []string
+		expectedNodeCount int
+		expectedLeafCount int
+	}
+	// sha256(testKey)  = 0001...
+	// sha256(testKey2) = 1000... common prefix len 0; 3 nodes (root + 2 leaf)
+	// sha256(foo)      = 0010... common prefix len 2; 5 nodes (3 inner + 2 leaf)
+	cases := []testCase{
+		{
+			desc:              "single key (testKey2) with a similar prefix to test key (testKey)",
+			keys:              []string{"testKey2"},
+			expectedNodeCount: 3,
+			expectedLeafCount: 2,
+		},
+		{
+			desc:              "single key (foo) with a different prefix to test key (testKey)",
+			keys:              []string{"foo"},
+			expectedNodeCount: 4,
+			expectedLeafCount: 2,
+		},
+		{
+			desc:              "override two existing keys",
+			keys:              []string{"testKey2", "foo"},
+			expectedNodeCount: 6,
+			expectedLeafCount: 3,
+		},
+		{
+			desc:              "4",
+			keys:              []string{"a", "b", "c", "d", "e"},
+			expectedNodeCount: 14,
+			expectedLeafCount: 6,
+		},
+	}
+	for tci, tc := range cases {
+		t.Run(tc.desc, func(t *testing.T) {
+			// Inserts a key-value pair for `testKey`
 			setup()
+			// Insert value for every key
 			for _, key := range tc.keys {
 				err = smst.Update([]byte(key), []byte("testValue2"), 10)
 				require.NoError(t, err, tci)
 			}
-			require.Equal(t, tc.count, nodeCount(t), tci)
+			require.Equal(t, tc.expectedNodeCount, nodeCount(t), tci)
+			require.Equal(t, uint64(tc.expectedLeafCount), impl.Count())
 
-			// Overwrite doesn't change count
+			// Overwrite doesn't change node or leaf count
 			for _, key := range tc.keys {
 				err = smst.Update([]byte(key), []byte("testValue3"), 10)
 				require.NoError(t, err, tci)
 			}
-			require.Equal(t, tc.count, nodeCount(t), tci)
+			require.Equal(t, tc.expectedNodeCount, nodeCount(t), tci)
+			require.Equal(t, uint64(tc.expectedLeafCount), impl.Count())
 
 			// Deletion removes all nodes except root
 			for _, key := range tc.keys {
@@ -420,13 +452,15 @@ func TestSMST_OrphanRemoval(t *testing.T) {
 				require.NoError(t, err, tci)
 			}
 			require.Equal(t, 1, nodeCount(t), tci)
+			require.Equal(t, uint64(1), impl.Count())
 
 			// Deleting and re-inserting a persisted node doesn't change count
 			require.NoError(t, smst.Delete([]byte("testKey")))
 			require.NoError(t, smst.Update([]byte("testKey"), []byte("testValue"), 10))
 			require.Equal(t, 1, nodeCount(t), tci)
-		}
-	})
+			require.Equal(t, uint64(1), impl.Count())
+		})
+	}
 }
 
 func TestSMST_TotalSum(t *testing.T) {
@@ -475,12 +509,20 @@ func TestSMST_TotalSum(t *testing.T) {
 	sum = smst.Sum()
 	require.Equal(t, sum, uint64(10))
 
+	// Check that the count is correct after deleting a key
+	count = smst.Count()
+	require.Equal(t, count, uint64(2))
+
 	// Check that the sum is correct after importing the trie
 	require.NoError(t, smst.Commit())
 	root2 := smst.Root()
 	smst = ImportSparseMerkleSumTrie(snm, sha256.New(), root2)
 	sum = smst.Sum()
 	require.Equal(t, sum, uint64(10))
+
+	// Check that the count is correct after importing the trie
+	count = smst.Count()
+	require.Equal(t, count, uint64(2))
 
 	// Calculate the total sum of a larger trie
 	snm = simplemap.NewSimpleMap()
@@ -492,6 +534,10 @@ func TestSMST_TotalSum(t *testing.T) {
 	require.NoError(t, smst.Commit())
 	sum = smst.Sum()
 	require.Equal(t, sum, uint64(49995000))
+
+	// Check that the count is correct after building a larger trie
+	count = smst.Count()
+	require.Equal(t, count, uint64(9999))
 }
 
 func TestSMST_Retrieval(t *testing.T) {
@@ -559,6 +605,7 @@ func TestSMST_Retrieval(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, []byte("value2"), value)
 	require.Equal(t, uint64(5), sum)
+	require.Equal(t, uint64(1), count)
 
 	value, sum, count, err = lazy.Get([]byte("key3"))
 	require.NoError(t, err)
@@ -568,4 +615,7 @@ func TestSMST_Retrieval(t *testing.T) {
 
 	sum = lazy.Sum()
 	require.Equal(t, sum, uint64(15))
+
+	count = lazy.Count()
+	require.Equal(t, count, uint64(3))
 }

--- a/smst_utils_test.go
+++ b/smst_utils_test.go
@@ -18,18 +18,24 @@ type SMSTWithStorage struct {
 	preimages kvstore.MapStore
 }
 
-// Update updates a key with a new value in the trie and adds the value to the
-// preimages KVStore
-// Preimages are the values prior to them being hashed - they are used to
-// confirm the values are in the trie
+// Update a key with a new value in the trie and add it to the preimages KVStore.
+// Preimages are the values prior to being hashed, used to confirm the values are in the trie.
 func (smst *SMSTWithStorage) Update(key, value []byte, sum uint64) error {
 	if err := smst.SMST.Update(key, value, sum); err != nil {
 		return err
 	}
 	valueHash := smst.valueHash(value)
+
+	// Append the sum to the value before storing it
 	var sumBz [sumSizeBytes]byte
 	binary.BigEndian.PutUint64(sumBz[:], sum)
 	value = append(value, sumBz[:]...)
+
+	// Append the count to the value before storing it
+	var countBz [countSizeBytes]byte
+	binary.BigEndian.PutUint64(countBz[:], 1)
+	value = append(value, countBz[:]...)
+
 	return smst.preimages.Set(valueHash, value)
 }
 
@@ -41,13 +47,15 @@ func (smst *SMSTWithStorage) Delete(key []byte) error {
 // GetValueSum returns the value and sum of the key stored in the trie, by
 // looking up the value hash in the preimages KVStore and extracting the sum
 func (smst *SMSTWithStorage) GetValueSum(key []byte) ([]byte, uint64, error) {
-	valueHash, sum, err := smst.Get(key)
+	valueHash, sum, _, err := smst.Get(key)
 	if err != nil {
 		return nil, 0, err
 	}
 	if valueHash == nil {
 		return nil, 0, nil
 	}
+
+	// Extract the value from the preimages KVStore
 	value, err := smst.preimages.Get(valueHash)
 	if err != nil {
 		if errors.Is(err, ErrKeyNotFound) {
@@ -57,13 +65,18 @@ func (smst *SMSTWithStorage) GetValueSum(key []byte) ([]byte, uint64, error) {
 		// Otherwise percolate up any other error
 		return nil, 0, err
 	}
+
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
+
+	// Extract the sum from the value
 	var sumBz [sumSizeBytes]byte
-	copy(sumBz[:], value[len(value)-sumSizeBytes:])
+	copy(sumBz[:], value[firstSumByteIdx:firstCountByteIdx])
 	storedSum := binary.BigEndian.Uint64(sumBz[:])
 	if storedSum != sum {
 		return nil, 0, fmt.Errorf("sum mismatch for %s: got %d, expected %d", string(key), storedSum, sum)
 	}
-	return value[:len(value)-sumSizeBytes], storedSum, nil
+
+	return value[:firstSumByteIdx], storedSum, nil
 }
 
 // Has returns true if the value at the given key is non-default, false otherwise.

--- a/smst_utils_test.go
+++ b/smst_utils_test.go
@@ -54,7 +54,6 @@ func (smst *SMSTWithStorage) GetValueSum(key []byte) ([]byte, uint64, error) {
 	if valueHash == nil {
 		return nil, 0, nil
 	}
-
 	// Extract the value from the preimages KVStore
 	value, err := smst.preimages.Get(valueHash)
 	if err != nil {

--- a/smst_utils_test.go
+++ b/smst_utils_test.go
@@ -47,7 +47,7 @@ func (smst *SMSTWithStorage) Delete(key []byte) error {
 // GetValueSum returns the value and sum of the key stored in the trie, by
 // looking up the value hash in the preimages KVStore and extracting the sum
 func (smst *SMSTWithStorage) GetValueSum(key []byte) ([]byte, uint64, error) {
-	valueHash, sum, _, err := smst.Get(key)
+	valueHash, sum, err := smst.Get(key)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/smst_utils_test.go
+++ b/smst_utils_test.go
@@ -65,7 +65,7 @@ func (smst *SMSTWithStorage) GetValueSum(key []byte) ([]byte, uint64, error) {
 		return nil, 0, err
 	}
 
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(value)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(value)
 
 	// Extract the sum from the value
 	var sumBz [sumSizeBytes]byte

--- a/smt.go
+++ b/smt.go
@@ -632,7 +632,7 @@ func (smt *SMT) parseSumTrieNode(data, digest []byte) (trieNode, error) {
 			digest:    digest,
 		}, nil
 	} else if isExtNode(data) {
-		pathBounds, path, childData, _ := smt.parseSumExtNode(data)
+		pathBounds, path, childData, _, _ := smt.parseSumExtNode(data)
 		return &extensionNode{
 			path:       path,
 			pathBounds: [2]byte(pathBounds),
@@ -641,7 +641,7 @@ func (smt *SMT) parseSumTrieNode(data, digest []byte) (trieNode, error) {
 			digest:     digest,
 		}, nil
 	} else if isInnerNode(data) {
-		leftData, rightData, _ := smt.th.parseSumInnerNode(data)
+		leftData, rightData, _, _ := smt.th.parseSumInnerNode(data)
 		return &innerNode{
 			leftChild:  &lazyNode{leftData},
 			rightChild: &lazyNode{rightData},

--- a/smt_example_test.go
+++ b/smt_example_test.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pokt-network/smt"
 	"github.com/pokt-network/smt/kvstore/simplemap"
 )
@@ -32,6 +34,44 @@ func TestExampleSMT(t *testing.T) {
 	// Attempt to verify the Merkle proof for "foo"="baz"
 	invalid, _ := smt.VerifyProof(proof, root, []byte("foo"), []byte("baz"), trie.Spec())
 
-	// Output: true false
-	t.Log(valid, invalid)
+	require.Equal(t, true, valid)
+	require.Equal(t, false, invalid)
 }
+
+// TestExampleSMT is a test that aims to act as an example of how to use the SMST.
+func TestExampleSMST(t *testing.T) {
+	// Initialize a new in-memory key-value store to store the nodes of the trie
+	// (Note: the trie only stores hashed values, not raw value data)
+	nodeStore := simplemap.NewSimpleMap()
+
+	// Initialize the trie
+	trie := smt.NewSparseMerkleSumTrie(nodeStore, sha256.New())
+
+	// Update the keys "foo[1,2,3]" with the value "bar[1,2,3]"
+	_ = trie.Update([]byte("foo1"), []byte("bar1"), 1)
+	_ = trie.Update([]byte("foo2"), []byte("bar2"), 2)
+	_ = trie.Update([]byte("foo3"), []byte("bar3"), 3)
+
+	// Commit the changes to the node store
+	_ = trie.Commit()
+
+	// Generate a Merkle proof for "foo1"
+	proof, _ := trie.Prove([]byte("foo1"))
+	root := trie.Root() // We also need the current trie root for the proof
+
+	// Verify the Merkle proof for "foo1"="bar1"
+	valid, _ := smt.VerifySumProof(proof, root, []byte("foo1"), []byte("bar1"), 1, 1, trie.Spec())
+	// Attempt to verify the Merkle proof for "foo"="baz"
+	invalid, _ := smt.VerifySumProof(proof, root, []byte("foo1"), []byte("baz1"), 1, 1, trie.Spec())
+
+	require.Equal(t, true, valid)
+	require.Equal(t, false, invalid)
+
+	sum := trie.Sum()
+	require.Equal(t, uint64(6), sum)
+
+	count := trie.Count()
+	require.Equal(t, uint64(3), count)
+}
+
+// TODO_IMPROVE: Show example of using the closest proof.

--- a/smt_example_test.go
+++ b/smt_example_test.go
@@ -31,47 +31,8 @@ func TestExampleSMT(t *testing.T) {
 
 	// Verify the Merkle proof for "foo"="bar"
 	valid, _ := smt.VerifyProof(proof, root, []byte("foo"), []byte("bar"), trie.Spec())
+	require.True(t, valid)
 	// Attempt to verify the Merkle proof for "foo"="baz"
 	invalid, _ := smt.VerifyProof(proof, root, []byte("foo"), []byte("baz"), trie.Spec())
-
-	require.Equal(t, true, valid)
-	require.Equal(t, false, invalid)
+	require.False(t, invalid)
 }
-
-// TestExampleSMT is a test that aims to act as an example of how to use the SMST.
-func TestExampleSMST(t *testing.T) {
-	// Initialize a new in-memory key-value store to store the nodes of the trie
-	// (Note: the trie only stores hashed values, not raw value data)
-	nodeStore := simplemap.NewSimpleMap()
-
-	// Initialize the trie
-	trie := smt.NewSparseMerkleSumTrie(nodeStore, sha256.New())
-
-	// Update the keys "foo[1,2,3]" with the value "bar[1,2,3]"
-	_ = trie.Update([]byte("foo1"), []byte("bar1"), 1)
-	_ = trie.Update([]byte("foo2"), []byte("bar2"), 2)
-	_ = trie.Update([]byte("foo3"), []byte("bar3"), 3)
-
-	// Commit the changes to the node store
-	_ = trie.Commit()
-
-	// Generate a Merkle proof for "foo1"
-	proof, _ := trie.Prove([]byte("foo1"))
-	root := trie.Root() // We also need the current trie root for the proof
-
-	// Verify the Merkle proof for "foo1"="bar1"
-	valid, _ := smt.VerifySumProof(proof, root, []byte("foo1"), []byte("bar1"), 1, 1, trie.Spec())
-	// Attempt to verify the Merkle proof for "foo"="baz"
-	invalid, _ := smt.VerifySumProof(proof, root, []byte("foo1"), []byte("baz1"), 1, 1, trie.Spec())
-
-	require.Equal(t, true, valid)
-	require.Equal(t, false, invalid)
-
-	sum := trie.Sum()
-	require.Equal(t, uint64(6), sum)
-
-	count := trie.Count()
-	require.Equal(t, uint64(3), count)
-}
-
-// TODO_IMPROVE: Show example of using the closest proof.

--- a/trie_spec.go
+++ b/trie_spec.go
@@ -33,6 +33,7 @@ func (spec *TrieSpec) placeholder() []byte {
 	if spec.sumTrie {
 		placeholder := spec.th.placeholder()
 		placeholder = append(placeholder, defaultEmptySum[:]...)
+		placeholder = append(placeholder, defaultEmptyCount[:]...)
 		return placeholder
 	}
 	return spec.th.placeholder()

--- a/trie_spec.go
+++ b/trie_spec.go
@@ -107,7 +107,7 @@ func (spec *TrieSpec) hashSumSerialization(data []byte) []byte {
 		return spec.digestSumNode(&ext)
 	}
 
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 
 	digest := spec.th.digestData(data)
 	digest = append(digest, data[firstSumByteIdx:firstCountByteIdx]...)
@@ -214,7 +214,7 @@ func (spec *TrieSpec) digestSumNode(node trieNode) []byte {
 	}
 	if *cache == nil {
 		preImage := spec.encodeSumNode(node)
-		firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(preImage)
+		firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(preImage)
 		*cache = spec.th.digestData(preImage)
 		*cache = append(*cache, preImage[firstSumByteIdx:firstCountByteIdx]...)
 		*cache = append(*cache, preImage[firstCountByteIdx:]...)
@@ -253,7 +253,7 @@ func (spec *TrieSpec) parseSumLeafNode(data []byte) (path, value []byte, weight,
 	path = data[prefixLen : prefixLen+spec.ph.PathSize()]
 	value = data[prefixLen+spec.ph.PathSize():]
 
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 
 	// Extract the sum from the encoded node data
 	var weightBz [sumSizeBytes]byte
@@ -276,7 +276,7 @@ func (spec *TrieSpec) parseSumExtNode(data []byte) (pathBounds, path, childData 
 	// panics if not an extension node
 	checkPrefix(data, extNodePrefix)
 
-	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx(data)
 
 	// Extract the sum from the encoded node data
 	var sumBz [sumSizeBytes]byte

--- a/trie_spec.go
+++ b/trie_spec.go
@@ -41,7 +41,7 @@ func (spec *TrieSpec) placeholder() []byte {
 // hashSize returns the hash size depending on the trie type
 func (spec *TrieSpec) hashSize() int {
 	if spec.sumTrie {
-		return spec.th.hashSize() + sumSizeBytes
+		return spec.th.hashSize() + sumSizeBytes + countSizeBytes
 	}
 	return spec.th.hashSize()
 }
@@ -100,13 +100,17 @@ func (spec *TrieSpec) hashSerialization(data []byte) []byte {
 // Used for verification of serialized proof data for sum trie nodes
 func (spec *TrieSpec) hashSumSerialization(data []byte) []byte {
 	if isExtNode(data) {
-		pathBounds, path, childHash, _ := spec.parseSumExtNode(data)
+		pathBounds, path, childHash, _, _ := spec.parseSumExtNode(data)
 		ext := extensionNode{path: path, child: &lazyNode{childHash}}
 		copy(ext.pathBounds[:], pathBounds)
 		return spec.digestSumNode(&ext)
 	}
+
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+
 	digest := spec.th.digestData(data)
-	digest = append(digest, data[len(data)-sumSizeBytes:]...)
+	digest = append(digest, data[firstSumByteIdx:firstCountByteIdx]...)
+	digest = append(digest, data[firstCountByteIdx:]...)
 	return digest
 }
 
@@ -188,7 +192,7 @@ func (spec *TrieSpec) encodeSumNode(node trieNode) (preImage []byte) {
 	return nil
 }
 
-// digestSumNode hashes a sum node returning its digest in the following form: [node hash]+[8 byte sum]
+// digestSumNode hashes a sum node returning its digest in the following form: [node hash]+[8 byte sum]+[8 byte count]
 func (spec *TrieSpec) digestSumNode(node trieNode) []byte {
 	if node == nil {
 		return spec.placeholder()
@@ -209,8 +213,10 @@ func (spec *TrieSpec) digestSumNode(node trieNode) []byte {
 	}
 	if *cache == nil {
 		preImage := spec.encodeSumNode(node)
+		firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(preImage)
 		*cache = spec.th.digestData(preImage)
-		*cache = append(*cache, preImage[len(preImage)-sumSizeBytes:]...)
+		*cache = append(*cache, preImage[firstSumByteIdx:firstCountByteIdx]...)
+		*cache = append(*cache, preImage[firstCountByteIdx:]...)
 	}
 	return *cache
 }
@@ -239,34 +245,51 @@ func (spec *TrieSpec) parseExtNode(data []byte) (pathBounds, path, childData []b
 
 // parseSumLeafNode parses a leafNode and returns its weight as well
 // // nolint: unused
-func (spec *TrieSpec) parseSumLeafNode(data []byte) (path, value []byte, weight uint64) {
+func (spec *TrieSpec) parseSumLeafNode(data []byte) (path, value []byte, weight, count uint64) {
 	// panics if not a leaf node
 	checkPrefix(data, leafNodePrefix)
 
 	path = data[prefixLen : prefixLen+spec.ph.PathSize()]
 	value = data[prefixLen+spec.ph.PathSize():]
 
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+
 	// Extract the sum from the encoded node data
 	var weightBz [sumSizeBytes]byte
-	copy(weightBz[:], value[len(value)-sumSizeBytes:])
+	copy(weightBz[:], data[firstSumByteIdx:firstCountByteIdx])
 	binary.BigEndian.PutUint64(weightBz[:], weight)
+
+	// Extract the count from the encoded node data
+	var countBz [countSizeBytes]byte
+	copy(countBz[:], value[firstCountByteIdx:])
+	binary.BigEndian.PutUint64(countBz[:], count)
+	if count != 1 {
+		panic("count for leaf node should always be 1")
+	}
 
 	return
 }
 
 // parseSumExtNode parses the pathBounds, path, child data and sum from the encoded extension node data
-func (spec *TrieSpec) parseSumExtNode(data []byte) (pathBounds, path, childData []byte, sum uint64) {
+func (spec *TrieSpec) parseSumExtNode(data []byte) (pathBounds, path, childData []byte, sum, count uint64) {
 	// panics if not an extension node
 	checkPrefix(data, extNodePrefix)
 
+	firstSumByteIdx, firstCountByteIdx := GetFirstMetaByteIdx(data)
+
 	// Extract the sum from the encoded node data
 	var sumBz [sumSizeBytes]byte
-	copy(sumBz[:], data[len(data)-sumSizeBytes:])
+	copy(sumBz[:], data[firstSumByteIdx:firstCountByteIdx])
 	binary.BigEndian.PutUint64(sumBz[:], sum)
+
+	// Extract the count from the encoded node data
+	var countBz [countSizeBytes]byte
+	copy(countBz[:], data[firstCountByteIdx:])
+	binary.BigEndian.PutUint64(countBz[:], count)
 
 	// +2 represents the length of the pathBounds
 	pathBounds = data[prefixLen : prefixLen+2]
 	path = data[prefixLen+2 : prefixLen+2+spec.ph.PathSize()]
-	childData = data[prefixLen+2+spec.ph.PathSize() : len(data)-sumSizeBytes]
+	childData = data[prefixLen+2+spec.ph.PathSize() : firstSumByteIdx]
 	return
 }

--- a/types.go
+++ b/types.go
@@ -18,6 +18,8 @@ var (
 	defaultEmptyValue []byte
 	// defaultEmptySum is the default sum value for a leaf node
 	defaultEmptySum [sumSizeBytes]byte
+	// defaultEmptyCount is the default count value for a leaf node
+	defaultEmptyCount [countSizeBytes]byte
 )
 
 // MerkleRoot is a type alias for a byte slice returned from the Root method
@@ -64,7 +66,7 @@ type SparseMerkleSumTrie interface {
 	// Delete deletes a value from the SMST. Raises an error if the key is not present.
 	Delete(key []byte) error
 	// Get descends the trie to access a value. Returns nil if key is not present.
-	Get(key []byte) ([]byte, uint64, error)
+	Get(key []byte) (data []byte, sum uint64, count uint64, err error)
 	// Root computes the Merkle root digest.
 	Root() MerkleRoot
 	// Sum computes the total sum of the Merkle trie

--- a/types.go
+++ b/types.go
@@ -71,6 +71,8 @@ type SparseMerkleSumTrie interface {
 	Root() MerkleRoot
 	// Sum computes the total sum of the Merkle trie
 	Sum() uint64
+	// Count returns the total number of non-empty leaves in the trie
+	Count() uint64
 	// Prove computes a Merkle proof of inclusion or exclusion of a key.
 	Prove(key []byte) (*SparseMerkleProof, error)
 	// ProveClosest computes a Merkle proof of inclusion for a key in the trie

--- a/types.go
+++ b/types.go
@@ -66,7 +66,7 @@ type SparseMerkleSumTrie interface {
 	// Delete deletes a value from the SMST. Raises an error if the key is not present.
 	Delete(key []byte) error
 	// Get descends the trie to access a value. Returns nil if key is not present.
-	Get(key []byte) (data []byte, sum uint64, count uint64, err error)
+	Get(key []byte) (data []byte, sum, count uint64, err error)
 	// Root computes the Merkle root digest.
 	Root() MerkleRoot
 	// Sum computes the total sum of the Merkle trie

--- a/types.go
+++ b/types.go
@@ -66,7 +66,7 @@ type SparseMerkleSumTrie interface {
 	// Delete deletes a value from the SMST. Raises an error if the key is not present.
 	Delete(key []byte) error
 	// Get descends the trie to access a value. Returns nil if key is not present.
-	Get(key []byte) (data []byte, sum, count uint64, err error)
+	Get(key []byte) (data []byte, sum uint64, err error)
 	// Root computes the Merkle root digest.
 	Root() MerkleRoot
 	// Sum computes the total sum of the Merkle trie


### PR DESCRIPTION
## Summary

- **What?** Introduce `count` to get the number of non-empty leaf nodes in every sub-trie
- **How?** Very similar to `sum` in its implementation
- **Why?** Needed to implement Relay Mining and get a reference value for the number of requests, not necessary their cost in terms of price or compute (i.e. compute units, weight, sum, etc...)
- **Other**: This needs to be part of the commitment and irrespective of the underlying key-value store engine

## Issue

- https://github.com/pokt-network/poktroll/issues/542

## Type of change

Please mark the relevant option(s):

- [x] New feature, functionality or library
- [ ] Bug fix
- [ ] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)

## Testing

- [x] **Run all unit tests**: `make test_all`
- [ ] **Run all/relevant benchmarks (if optimising)**: `make benchmark_{all | suite name}`

## Required Checklist

- [x] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code ([`godoc` format comments](https://go.dev/blog/godoc) see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))

### If Applicable Checklist

- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated any relevant README(s)/documentation and left TODOs throughout the codebase
- [ ] Add or update any relevant or supporting [mermaid](https://mermaid-js.github.io/mermaid/) diagrams
