### PR TITLE
refactor: MerkleRoot#Sum() as MerkleRoot#MustSum()

### DIFF
--- a/root.go
+++ b/root.go
@@ -1,6 +1,9 @@
 package smt
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+	"fmt"
+)
 
 const (
 	// These are intentionally exposed to allow for for testing and custom
@@ -9,19 +12,31 @@ const (
 	SmstRootSizeBytes = SmtRootSizeBytes + sumSizeBytes + countSizeBytes
 )
 
-// Sum returns the uint64 sum of the merkle root, it checks the length of the
+// MustSum returns the uint64 sum of the merkle root, it checks the length of the
 // merkle root and if it is no the same as the size of the SMST's expected
 // root hash it will panic.
-func (r MerkleRoot) Sum() uint64 {
+func (r MerkleRoot) MustSum() uint64 {
+	sum, err := r.Sum()
+	if err != nil {
+		panic(err)
+	}
+
+	return sum
+}
+
+// Sum returns the uint64 sum of the merkle root, it checks the length of the
+// merkle root and if it is no the same as the size of the SMST's expected
+// root hash it will return an error.
+func (r MerkleRoot) Sum() (uint64, error) {
 	if len(r)%SmtRootSizeBytes == 0 {
-		panic("root#sum: not a merkle sum trie")
+		return 0, fmt.Errorf("root#sum: not a merkle sum trie")
 	}
 
 	firstSumByteIdx, firstCountByteIdx := getFirstMetaByteIdx([]byte(r))
 
 	var sumBz [sumSizeBytes]byte
 	copy(sumBz[:], []byte(r)[firstSumByteIdx:firstCountByteIdx])
-	return binary.BigEndian.Uint64(sumBz[:])
+	return binary.BigEndian.Uint64(sumBz[:]), nil
 }
 
 // Count returns the uint64 count of the merkle root, a cryptographically secure


### PR DESCRIPTION
## Summary

- Refactors `MerkleRoot#Sum()` to return an error argument.
- Adds `MerkleRoot#MustSum()` which behaves as `MerkleRoot#Sum()` previously did.

### Human Summary

### AI Summary

reviewpad:summary

## Issue

Fixes https://github.com/pokt-network/poktroll/issues/584

We need proper error handling in consumer code where the root has not been checked for validity.

## Type of change

Please mark the relevant option(s):

- [ ] New feature, functionality or library
- [ ] Bug fix
- [x] Code health or cleanup
- [ ] Documentation
- [ ] Other (specify)


## Testing

- [ ] **Run all unit tests**: `make test_all`
- [ ] **Run all/relevant benchmarks (if optimising)**: `make benchmark_{all | suite name}`


## Required Checklist

- [ ] I have tested my changes using the available tooling
- [x] I have performed a self-review of my own code
- [ ] I have commented my code ([`godoc` format comments](https://go.dev/blog/godoc) see: [tip.golang.org/doc/comment](https://tip.golang.org/doc/comment))

### If Applicable Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have updated any relevant README(s)/documentation and left TODOs throughout the codebase
- [ ] Add or update any relevant or supporting [mermaid](https://mermaid-js.github.io/mermaid/) diagrams
